### PR TITLE
JikongBMS: the battery current value is 32 bit.

### DIFF
--- a/sensor_classes/JikongBMS.js
+++ b/sensor_classes/JikongBMS.js
@@ -217,7 +217,7 @@ class JikongBMS extends BTSensor {
       buffer
     ) => {
       this.currentProperties._current =
-        buffer.readInt16LE(126 + this.offset * 2) / 1000;
+        buffer.readInt32LE(126 + this.offset * 2) / 1000;
       return this.currentProperties._current;
     };
 


### PR DESCRIPTION
Hi,

I was seeing odd values, e.g. ~ -80A discharge was being shown as ~ 2A charge.

Assuming a 32bit value, rather than a 16bit one fixed the mismatch.

Cheers
Phil