### PR TITLE
feat: add WattCycle/XDZN BMS sensor (BLE 0xFFF0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ It's pretty easy to write and deploy your own sensor class for any currently uns
 |[AC DC Systems](https://marinedcac.com) | [Bank Manager](https://marinedcac.com/pages/bankmanager) hybrid (Pb and Li) charger|
 |[Ective](https://ective.de/)| Also Topband(?), Skanbatt and others |
 |[Leagend](https://leagend.com)| BM 2/6/7 Battery Monitors aka Alcel BM200 and others. See: https://leagend.com/products/bm6|
+|[WattCycle](https://wattcycle.com/) / XDZN | LiFePO4 smart batteries (XDZN/WT-prefixed BLE name, BMS service `0xFFF0`). Reverse-engineered from `com.gz.wattcycle` Android APK via [wattcycle_ble](https://github.com/qume/wattcycle_ble). |
 
 
 ### Environmental 

--- a/sensor_classes/WattCycleBMS.js
+++ b/sensor_classes/WattCycleBMS.js
@@ -1,0 +1,358 @@
+"use strict";
+
+const BTSensor = require("../BTSensor");
+const proto = require("./wattcycle/protocol.js");
+
+const C_TO_K = 273.15;
+const AH_TO_AS = 3600;
+
+class WattCycleBMS extends BTSensor {
+  static Domain = BTSensor.SensorDomains.electrical;
+
+  static SERVICE_UUID = proto.SERVICE_UUID;
+  static NOTIFY_CHAR_UUID = proto.NOTIFY_UUID;
+  static WRITE_CHAR_UUID = proto.WRITE_UUID;
+  static AUTH_CHAR_UUID = proto.AUTH_UUID;
+
+  static identify(device) {
+    return null;
+  }
+
+  async initSchema() {
+    super.initSchema();
+    this.addDefaultParam("batteryID");
+
+    this.addDefaultPath("voltage", "electrical.batteries.voltage").read = (aq) =>
+      aq.moduleVoltage;
+
+    this.addDefaultPath("current", "electrical.batteries.current").read = (aq) =>
+      aq.current;
+
+    this.addDefaultPath(
+      "remainingCapacity",
+      "electrical.batteries.capacity.remaining"
+    ).read = (aq) => aq.remainingCapacity * AH_TO_AS;
+
+    this.addDefaultPath(
+      "capacity",
+      "electrical.batteries.capacity.actual"
+    ).read = (aq) => aq.totalCapacity * AH_TO_AS;
+
+    this.addDefaultPath(
+      "designCapacity",
+      "electrical.batteries.capacity.nominal"
+    ).read = (aq) => aq.designCapacity * AH_TO_AS;
+
+    this.addDefaultPath("cycles", "electrical.batteries.cycles").read = (aq) =>
+      aq.cycleNumber;
+
+    this.addDefaultPath(
+      "SOC",
+      "electrical.batteries.capacity.stateOfCharge"
+    ).read = (aq) => aq.soc / 100;
+
+    this.addDefaultPath(
+      "SOH",
+      "electrical.batteries.capacity.stateOfHealth"
+    ).read = (aq) => (aq.soh == null ? null : aq.soh / 100);
+
+    this.addDefaultPath(
+      "temperature",
+      "electrical.batteries.temperature"
+    ).read = (aq) => {
+      const temps = aq.cellTemperatures.length
+        ? aq.cellTemperatures
+        : [aq.mosTemperature, aq.pcbTemperature];
+      return Math.max(...temps) + C_TO_K;
+    };
+
+    this.addMetadatum(
+      "mosTemperature",
+      "K",
+      "MOSFET temperature",
+      (aq) => aq.mosTemperature + C_TO_K
+    ).default = "electrical.batteries.{batteryID}.mosTemperature";
+
+    this.addMetadatum(
+      "pcbTemperature",
+      "K",
+      "PCB temperature",
+      (aq) => aq.pcbTemperature + C_TO_K
+    ).default = "electrical.batteries.{batteryID}.pcbTemperature";
+
+    if (this.numberOfCells == undefined || this.numberOfTemps == undefined) {
+      try {
+        await this.initGATTConnection();
+        const aq = await this._readAnalogQuantity();
+        this.numberOfCells = aq.cellCount;
+        this.numberOfTemps = Math.max(0, aq.cellTemperatures.length);
+      } catch (e) {
+        console.error(e);
+        this.numberOfCells = 4;
+        this.numberOfTemps = 2;
+      }
+    }
+
+    for (let i = 0; i < this.numberOfCells; i++) {
+      this.addMetadatum(
+        `cell${i}Voltage`,
+        "V",
+        `Cell ${i + 1} voltage`,
+        (aq) => aq.cellVoltages[i]
+      ).default = `electrical.batteries.{batteryID}.cell${i}.voltage`;
+      this.addMetadatum(
+        `cell${i}Balance`,
+        "",
+        `Cell ${i + 1} balance state`
+      ).default = `electrical.batteries.{batteryID}.cell${i}.balance`;
+    }
+    for (let i = 0; i < this.numberOfTemps; i++) {
+      this.addMetadatum(
+        `cellTemp${i}`,
+        "K",
+        `Cell temperature ${i + 1}`,
+        (aq) => aq.cellTemperatures[i] + C_TO_K
+      ).default = `electrical.batteries.{batteryID}.Temperature${i + 1}`;
+    }
+
+    this.addMetadatum(
+      "protectionStatus",
+      "",
+      "Active protections",
+      (wi) => ({
+        protections: wi.protections,
+        faults: wi.faults,
+        warnings: wi.warnings,
+      })
+    ).default = "electrical.batteries.{batteryID}.protectionStatus";
+  }
+
+  hasGATT() {
+    return true;
+  }
+
+  usingGATT() {
+    return true;
+  }
+
+  async initGATTNotifications() {
+    this.debug(`${this.getName()}::initGATTNotifications`);
+  }
+
+  async initGATTConnection(isReconnecting = false) {
+    if (this.rxChar) {
+      try {
+        this.rxChar.removeAllListeners();
+        await this.rxChar.stopNotifications();
+      } catch (e) {
+        this.debug(`error stopping notifications: ${e.message}`);
+      }
+    }
+
+    try {
+      await super.initGATTConnection(isReconnecting);
+      const gattServer = await this.getGATTServer();
+      this.btService = await gattServer.getPrimaryService(this.constructor.SERVICE_UUID);
+      this.rxChar = await this.btService.getCharacteristic(this.constructor.NOTIFY_CHAR_UUID);
+      this.txChar = await this.btService.getCharacteristic(this.constructor.WRITE_CHAR_UUID);
+
+      try {
+        this.authChar = await this.btService.getCharacteristic(this.constructor.AUTH_CHAR_UUID);
+      } catch (e) {
+        this.debug(`Auth characteristic not found: ${e.message}`);
+        this.authChar = null;
+      }
+
+      await this.rxChar.startNotifications();
+
+      if (this.authChar) {
+        try {
+          await this.authChar.writeValue(Buffer.from(proto.AUTH_KEY));
+        } catch (e) {
+          this.debug(`Auth write failed (continuing): ${e.message}`);
+        }
+      }
+
+      this.frameHead = await this._detectFrameHead();
+    } catch (e) {
+      console.error(e);
+      this.setError(e.message);
+    }
+  }
+
+  async _detectFrameHead() {
+    for (const head of [proto.FRAME_HEAD, proto.FRAME_HEAD_ALT]) {
+      try {
+        await this._sendRead(proto.DP_PRODUCT_INFO, 3000, head);
+        this.debug(`${this.getName()} frame head = 0x${head.toString(16)}`);
+        return head;
+      } catch (e) {
+        this.debug(`Frame head 0x${head.toString(16)} did not respond: ${e.message}`);
+      }
+    }
+    return proto.FRAME_HEAD;
+  }
+
+  /**
+   * Send a read frame and reassemble notifications until the response is complete.
+   *
+   * @param {number} dpAddress
+   * @param {number} [timeoutMs=10000]
+   * @param {number} [head]
+   * @returns {Promise<{frame: object, payload: Buffer}>}
+   */
+  _sendRead(dpAddress, timeoutMs = 10000, head = undefined) {
+    const frameHead = head ?? this.frameHead ?? proto.FRAME_HEAD;
+    return new Promise(async (resolve, reject) => {
+      if (!this.rxChar || !this.txChar) {
+        reject(new Error(`${this.getName()}::_sendRead chars unavailable`));
+        return;
+      }
+      const chunks = [];
+      let total = 0;
+      let expected = -1;
+      let settled = false;
+
+      const cleanup = () => {
+        if (this.rxChar) this.rxChar.removeListener("valuechanged", onValue);
+        clearTimeout(timer);
+      };
+
+      const timer = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(new Error(`Response timed out from ${this.getName()} (DP 0x${dpAddress.toString(16)})`));
+      }, timeoutMs);
+
+      const onValue = (buffer) => {
+        if (settled) return;
+        if (chunks.length === 0) {
+          if (buffer.length < 8) return;
+          if (buffer[0] !== proto.FRAME_HEAD && buffer[0] !== proto.FRAME_HEAD_ALT) return;
+          if (buffer.readUInt16BE(4) !== dpAddress) return;
+          expected = proto.expectedResponseLength(buffer);
+          if (expected == null) return;
+        }
+        chunks.push(buffer);
+        total += buffer.length;
+        if (total >= expected) {
+          const full = Buffer.concat(chunks, total).subarray(0, expected);
+          settled = true;
+          cleanup();
+          if (!proto.verifyCrc(full)) {
+            reject(new Error(`Bad CRC from ${this.getName()} on DP 0x${dpAddress.toString(16)}`));
+            return;
+          }
+          const frame = proto.parseFrame(full);
+          if (!frame) {
+            reject(new Error(`Invalid frame from ${this.getName()} on DP 0x${dpAddress.toString(16)}`));
+            return;
+          }
+          resolve({ frame, payload: frame.data });
+        }
+      };
+
+      this.rxChar.on("valuechanged", onValue);
+      try {
+        const tx = proto.buildReadFrame(dpAddress, 0, frameHead);
+        await this.txChar.writeValueWithoutResponse(Buffer.from(tx));
+      } catch (e) {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(e);
+      }
+    });
+  }
+
+  async _readAnalogQuantity() {
+    const { payload } = await this._sendRead(proto.DP_ANALOG_QUANTITY);
+    const aq = proto.parseAnalogQuantity(payload);
+    if (!aq) throw new Error(`Failed to parse Analog Quantity for ${this.getName()}`);
+    return aq;
+  }
+
+  async _readWarningInfo() {
+    const { payload } = await this._sendRead(proto.DP_WARNING_INFO);
+    const wi = proto.parseWarningInfo(payload);
+    if (!wi) throw new Error(`Failed to parse Warning Info for ${this.getName()}`);
+    return wi;
+  }
+
+  async emitGATT() {
+    try {
+      const aq = await this._readAnalogQuantity();
+      [
+        "voltage",
+        "current",
+        "remainingCapacity",
+        "capacity",
+        "designCapacity",
+        "cycles",
+        "SOC",
+        "SOH",
+        "temperature",
+        "mosTemperature",
+        "pcbTemperature",
+      ].forEach((tag) => this.emitData(tag, aq));
+
+      const cellCount = Math.min(this.numberOfCells ?? aq.cellCount, aq.cellCount);
+      for (let i = 0; i < cellCount; i++) this.emitData(`cell${i}Voltage`, aq);
+
+      const tCount = Math.min(this.numberOfTemps ?? aq.cellTemperatures.length, aq.cellTemperatures.length);
+      for (let i = 0; i < tCount; i++) this.emitData(`cellTemp${i}`, aq);
+    } catch (e) {
+      console.error(e);
+      this.debug(`${this.getName()}::emitGATT analog read failed: ${e.message}`);
+    }
+
+    try {
+      const wi = await this._readWarningInfo();
+      this.emitData("protectionStatus", wi);
+      const limit = Math.min(this.numberOfCells ?? wi.cellCount, wi.balanceStates.length);
+      for (let i = 0; i < limit; i++) {
+        this.emit(`cell${i}Balance`, wi.balanceStates[i] ? 1 : 0);
+      }
+    } catch (e) {
+      console.error(e);
+      this.debug(`${this.getName()}::emitGATT warning read failed: ${e.message}`);
+    }
+  }
+
+  async initGATTInterval() {
+    this.debug(`${this.getName()}::initGATTInterval pollFreq=${this?.pollFreq}`);
+    this.intervalID = setInterval(
+      async () => {
+        this._error = false;
+        try {
+          if (!(await this.device.isConnected())) {
+            await this.initGATTConnection(true);
+          }
+          await this.emitGATT();
+        } catch (e) {
+          this.setError(e.message);
+        }
+      },
+      (this?.pollFreq ?? 40) * 1000
+    );
+    try {
+      await this.emitGATT();
+    } catch (e) {
+      console.error(e);
+      this.setError(e.message);
+    }
+  }
+
+  async deactivateGATT() {
+    this.debug(`${this.getName()}::deactivateGATT`);
+    if (this.intervalID) {
+      clearInterval(this.intervalID);
+      this.intervalID = null;
+    }
+    await this.stopGATTNotifications(this.rxChar);
+    await super.deactivateGATT();
+  }
+}
+
+module.exports = WattCycleBMS;

--- a/sensor_classes/wattcycle/NOTICE.md
+++ b/sensor_classes/wattcycle/NOTICE.md
@@ -1,0 +1,32 @@
+# WattCycle / XDZN BMS — Attribution
+
+The protocol implementation in `protocol.js` is a JavaScript port of
+[wattcycle_ble](https://github.com/qume/wattcycle_ble) (MIT, © 2025 Luke),
+which itself reverse-engineered the protocol from the
+`com.gz.wattcycle` Android APK using `jadx`.
+
+## What was ported
+
+- Modbus CRC16 lookup tables (`CRC_HI`, `CRC_LO`)
+- Frame format (`HEAD/VER/ADDR/FUNC/.../CRC/TAIL`)
+- Parsers for Analog Quantity (DP `0x008C`), Warning Info (DP `0x008D`),
+  Product Info (DP `0x0092`)
+- Auth handshake (`HiLink` written to characteristic `FFFA`)
+
+## Protocol reference
+
+See the upstream `PROTOCOL.md`:
+https://github.com/qume/wattcycle_ble/blob/main/PROTOCOL.md
+
+## Tested devices
+
+The fixtures in `spec/wattcycle_protocol.test.js` are real captured frames
+from an **XDZN_001_EF2F** unit (firmware `WT12_20004SW10_L447`, 4S 314Ah
+LiFePO4) provided by the upstream project.
+
+## License
+
+This file and `protocol.js` are derivative works of MIT-licensed code.
+Original copyright notice retained per the MIT terms:
+
+> MIT License — Copyright (c) 2025 Luke

--- a/sensor_classes/wattcycle/cli-dbus.js
+++ b/sensor_classes/wattcycle/cli-dbus.js
@@ -1,0 +1,232 @@
+#!/usr/bin/env node
+/**
+ * Standalone WattCycle / XDZN BLE probe via BlueZ D-Bus.
+ *
+ * Uses @naugehyde/node-ble (same library as the plugin), so it does NOT
+ * require setcap/raw HCI access — it talks to the BlueZ daemon over
+ * D-Bus and works with whichever adapter BlueZ chose.
+ *
+ * Connects to the device, runs the HiLink auth handshake, autodetects
+ * the frame head, and prints decoded Analog Quantity / Warning Info /
+ * Product Info responses.
+ *
+ * Usage:
+ *   sudo node sensor_classes/wattcycle/cli-dbus.js C0:D6:3C:5A:55:B2
+ *   ADAPTER=hci1 sudo node sensor_classes/wattcycle/cli-dbus.js C0:D6:3C:5A:55:B2
+ *
+ * For non-root usage, add a D-Bus policy under /etc/dbus-1/system.d/
+ * granting your user access to org.bluez (see project README / NOTICE).
+ */
+
+"use strict";
+
+const proto = require("./protocol.js");
+
+let createBluetooth;
+try {
+  ({ createBluetooth } = require("@naugehyde/node-ble"));
+} catch (e) {
+  console.error(
+    "Missing dependency: @naugehyde/node-ble\n" +
+      "Install with:\n  npm i @naugehyde/node-ble\n"
+  );
+  process.exit(2);
+}
+
+const TARGET_MAC = (process.argv[2] || "").toUpperCase();
+const ADAPTER_NAME = process.env.ADAPTER || null;
+const SCAN_TIMEOUT_MS = Number(process.env.SCAN_TIMEOUT || 25) * 1000;
+const READ_TIMEOUT_MS = 8000;
+
+if (!TARGET_MAC) {
+  console.error("Usage: node cli-dbus.js <MAC>  (e.g. C0:D6:3C:5A:55:B2)");
+  process.exit(2);
+}
+
+const log = (...args) => console.log("[wattcycle]", ...args);
+
+function awaitNotification(notifyChar, dpAddress, timeoutMs = READ_TIMEOUT_MS) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let total = 0;
+    let expected = -1;
+    let settled = false;
+
+    const cleanup = () => {
+      notifyChar.removeListener("valuechanged", onVal);
+      clearTimeout(timer);
+    };
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(new Error(`Timeout waiting DP 0x${dpAddress.toString(16)}`));
+    }, timeoutMs);
+
+    const onVal = (buffer) => {
+      if (settled) return;
+      if (chunks.length === 0) {
+        if (buffer.length < 8) return;
+        if (buffer[0] !== proto.FRAME_HEAD && buffer[0] !== proto.FRAME_HEAD_ALT) return;
+        if (buffer.readUInt16BE(4) !== dpAddress) return;
+        expected = proto.expectedResponseLength(buffer);
+      }
+      chunks.push(buffer);
+      total += buffer.length;
+      if (total >= expected) {
+        const full = Buffer.concat(chunks, total).subarray(0, expected);
+        settled = true;
+        cleanup();
+        if (!proto.verifyCrc(full)) {
+          reject(new Error("CRC mismatch"));
+          return;
+        }
+        const frame = proto.parseFrame(full);
+        if (!frame) return reject(new Error("Bad frame"));
+        resolve(frame);
+      }
+    };
+    notifyChar.on("valuechanged", onVal);
+  });
+}
+
+async function readDP(notifyChar, writeChar, dpAddress, frameHead) {
+  const tx = proto.buildReadFrame(dpAddress, 0, frameHead);
+  const waiter = awaitNotification(notifyChar, dpAddress);
+  await writeChar.writeValueWithoutResponse(Buffer.from(tx));
+  return waiter;
+}
+
+async function detectFrameHead(notifyChar, writeChar) {
+  for (const head of [proto.FRAME_HEAD, proto.FRAME_HEAD_ALT]) {
+    try {
+      log(`probing frame head 0x${head.toString(16)}...`);
+      await readDP(notifyChar, writeChar, proto.DP_PRODUCT_INFO, head);
+      log(`frame head 0x${head.toString(16)} OK`);
+      return head;
+    } catch (e) {
+      log(`head 0x${head.toString(16)} no response: ${e.message}`);
+    }
+  }
+  throw new Error("Could not detect frame head; device unresponsive");
+}
+
+function fmt(n, digits = 3) {
+  if (n == null) return "—";
+  return Number(n).toFixed(digits);
+}
+
+function dump(label, obj) {
+  console.log(`\n--- ${label} ---`);
+  console.log(JSON.stringify(obj, null, 2));
+}
+
+async function getAdapter(bluetooth) {
+  if (ADAPTER_NAME) {
+    log(`using adapter ${ADAPTER_NAME}`);
+    return bluetooth.adapter(ADAPTER_NAME);
+  }
+  return bluetooth.defaultAdapter();
+}
+
+async function main() {
+  const { bluetooth, destroy } = createBluetooth();
+  const adapter = await getAdapter(bluetooth);
+  if (!(await adapter.isPowered())) {
+    log("powering on adapter...");
+    await adapter.setPowered(true);
+  }
+  if (!(await adapter.isDiscovering())) {
+    log("starting discovery...");
+    try {
+      await adapter.startDiscovery();
+    } catch (e) {
+      log(`discovery start warning: ${e.message}`);
+    }
+  }
+
+  log(`waiting for ${TARGET_MAC} (timeout ${SCAN_TIMEOUT_MS / 1000}s)...`);
+  const device = await adapter.waitDevice(TARGET_MAC, SCAN_TIMEOUT_MS);
+  try { await adapter.stopDiscovery(); } catch (_e) { /* ignore */ }
+
+  log(`connecting to ${TARGET_MAC}...`);
+  await device.connect();
+  log("connected");
+
+  try {
+    const gatt = await device.gatt();
+    const service = await gatt.getPrimaryService(proto.SERVICE_UUID);
+    const notifyChar = await service.getCharacteristic(proto.NOTIFY_UUID);
+    const writeChar = await service.getCharacteristic(proto.WRITE_UUID);
+
+    let authChar = null;
+    try {
+      authChar = await service.getCharacteristic(proto.AUTH_UUID);
+    } catch (e) {
+      log(`auth char missing: ${e.message}`);
+    }
+
+    await notifyChar.startNotifications();
+    log("notifications enabled on FFF1");
+
+    if (authChar) {
+      try {
+        await authChar.writeValue(Buffer.from(proto.AUTH_KEY));
+        log("auth: 'HiLink' written to FFFA");
+      } catch (e) {
+        log(`auth write failed (continuing): ${e.message}`);
+      }
+    }
+
+    const head = await detectFrameHead(notifyChar, writeChar);
+
+    const product = await readDP(notifyChar, writeChar, proto.DP_PRODUCT_INFO, head);
+    dump("Product Info (DP 0x0092)", proto.parseProductInfo(product.data));
+
+    const aqFrame = await readDP(notifyChar, writeChar, proto.DP_ANALOG_QUANTITY, head);
+    const aq = proto.parseAnalogQuantity(aqFrame.data);
+    dump("Analog Quantity (DP 0x008C)", aq);
+    if (aq) {
+      console.log(
+        `\n  Voltage:  ${fmt(aq.moduleVoltage, 2)} V` +
+          `   Current: ${fmt(aq.current, 2)} A` +
+          `   SOC: ${aq.soc}%` +
+          (aq.soh != null ? `   SOH: ${aq.soh}%` : "")
+      );
+      console.log(`  Cells:    ${aq.cellVoltages.map((v) => fmt(v, 3)).join(" / ")} V`);
+      console.log(
+        `  Temps:    MOS=${fmt(aq.mosTemperature, 1)}°C  PCB=${fmt(
+          aq.pcbTemperature,
+          1
+        )}°C  cells=[${aq.cellTemperatures.map((t) => fmt(t, 1)).join(", ")}] °C`
+      );
+      console.log(
+        `  Capacity: rem ${fmt(aq.remainingCapacity, 1)} Ah / total ${fmt(
+          aq.totalCapacity,
+          1
+        )} Ah / design ${fmt(aq.designCapacity, 1)} Ah  cycles=${aq.cycleNumber}`
+      );
+    }
+
+    const wiFrame = await readDP(notifyChar, writeChar, proto.DP_WARNING_INFO, head);
+    const wi = proto.parseWarningInfo(wiFrame.data);
+    dump("Warning Info (DP 0x008D)", wi);
+    if (wi) {
+      console.log(`\n  protections: ${wi.protections.length ? wi.protections.join(", ") : "(none)"}`);
+      console.log(`  faults:      ${wi.faults.length ? wi.faults.join(", ") : "(none)"}`);
+      console.log(`  warnings:    ${wi.warnings.length ? wi.warnings.join(", ") : "(none)"}`);
+    }
+  } finally {
+    try {
+      await device.disconnect();
+      log("disconnected");
+    } catch (_e) { /* ignore */ }
+    destroy();
+    setTimeout(() => process.exit(0), 200);
+  }
+}
+
+main().catch((e) => {
+  console.error("[wattcycle] ERROR:", e.stack || e.message);
+  process.exit(1);
+});

--- a/sensor_classes/wattcycle/cli-dbus.js
+++ b/sensor_classes/wattcycle/cli-dbus.js
@@ -124,7 +124,13 @@ function dump(label, obj) {
 async function getAdapter(bluetooth) {
   if (ADAPTER_NAME) {
     log(`using adapter ${ADAPTER_NAME}`);
-    return bluetooth.adapter(ADAPTER_NAME);
+    if (typeof bluetooth.getAdapter === "function") {
+      return bluetooth.getAdapter(ADAPTER_NAME);
+    }
+    if (typeof bluetooth.adapter === "function") {
+      return bluetooth.adapter(ADAPTER_NAME);
+    }
+    log(`adapter() not in this node-ble version; falling back to defaultAdapter()`);
   }
   return bluetooth.defaultAdapter();
 }

--- a/sensor_classes/wattcycle/cli.js
+++ b/sensor_classes/wattcycle/cli.js
@@ -1,0 +1,292 @@
+#!/usr/bin/env node
+/**
+ * Standalone WattCycle / XDZN BLE probe.
+ *
+ * Scans for XDZN/WT-prefixed devices, connects to the first match (or to
+ * a MAC passed as argv[2]), runs the HiLink auth handshake, and prints
+ * decoded Analog Quantity / Warning Info / Product Info responses.
+ *
+ * Useful for verifying protocol port + hardware before wiring the
+ * sensor into SignalK.
+ *
+ * Usage:
+ *   node sensor_classes/wattcycle/cli.js               # scan + use first XDZN/WT match
+ *   node sensor_classes/wattcycle/cli.js AA:BB:CC:DD:EE:FF
+ *   SCAN_TIMEOUT=15 node sensor_classes/wattcycle/cli.js
+ *
+ * Requires (Linux only, root or BLE caps):
+ *   npm i @abandonware/noble
+ *   sudo setcap cap_net_raw+eip $(eval readlink -f $(which node))
+ */
+
+"use strict";
+
+const proto = require("./protocol.js");
+
+let noble;
+try {
+  noble = require("@abandonware/noble");
+} catch (e) {
+  console.error(
+    "Missing dependency: @abandonware/noble\n" +
+      "Install with:\n  npm i @abandonware/noble\n" +
+      "(Linux only; on the Pi: sudo apt-get install -y libudev-dev build-essential)"
+  );
+  process.exit(2);
+}
+
+const TARGET_MAC = (process.argv[2] || "").toLowerCase();
+const SCAN_TIMEOUT = Number(process.env.SCAN_TIMEOUT || 20) * 1000;
+const READ_TIMEOUT_MS = 8000;
+const SERVICE_SHORT = "fff0";
+const NOTIFY_SHORT = "fff1";
+const WRITE_SHORT = "fff2";
+const AUTH_SHORT = "fffa";
+
+const log = (...args) => console.log("[wattcycle]", ...args);
+const fail = (msg, code = 1) => {
+  console.error("[wattcycle] ERROR:", msg);
+  process.exit(code);
+};
+
+function isWattCycleName(name) {
+  if (!name) return false;
+  const upper = name.toUpperCase();
+  return proto.DEVICE_NAME_PREFIXES.some((p) => upper.startsWith(p));
+}
+
+function pickPeripheral() {
+  return new Promise((resolve, reject) => {
+    const seen = new Set();
+    const timer = setTimeout(() => {
+      noble.stopScanning();
+      reject(new Error(`No matching device found in ${SCAN_TIMEOUT / 1000}s`));
+    }, SCAN_TIMEOUT);
+
+    noble.on("discover", (p) => {
+      const name = p.advertisement?.localName || "";
+      const mac = (p.address || "").toLowerCase();
+      const key = `${mac}|${name}`;
+      if (!seen.has(key)) {
+        seen.add(key);
+        log(`discovered: ${mac || "(no addr)"}  name="${name}"  rssi=${p.rssi}`);
+      }
+      const matchByMac = TARGET_MAC && mac === TARGET_MAC;
+      const matchByName = !TARGET_MAC && isWattCycleName(name);
+      if (matchByMac || matchByName) {
+        clearTimeout(timer);
+        noble.stopScanning();
+        resolve(p);
+      }
+    });
+
+    noble.startScanning([], true);
+  });
+}
+
+function discoverChars(peripheral) {
+  return new Promise((resolve, reject) => {
+    peripheral.discoverSomeServicesAndCharacteristics(
+      [SERVICE_SHORT],
+      [NOTIFY_SHORT, WRITE_SHORT, AUTH_SHORT],
+      (err, _services, characteristics) => {
+        if (err) return reject(err);
+        const byUuid = Object.fromEntries(
+          characteristics.map((c) => [c.uuid.toLowerCase(), c])
+        );
+        const notify = byUuid[NOTIFY_SHORT];
+        const write = byUuid[WRITE_SHORT];
+        const auth = byUuid[AUTH_SHORT];
+        if (!notify || !write) {
+          return reject(new Error(`Missing characteristics: notify=${!!notify} write=${!!write}`));
+        }
+        resolve({ notify, write, auth });
+      }
+    );
+  });
+}
+
+function awaitNotification(notify, dpAddress, timeoutMs = READ_TIMEOUT_MS) {
+  return new Promise((resolve, reject) => {
+    const chunks = [];
+    let total = 0;
+    let expected = -1;
+    let settled = false;
+
+    const cleanup = () => {
+      notify.removeListener("data", onData);
+      clearTimeout(timer);
+    };
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(new Error(`Timeout waiting DP 0x${dpAddress.toString(16)}`));
+    }, timeoutMs);
+
+    const onData = (buffer) => {
+      if (settled) return;
+      if (chunks.length === 0) {
+        if (buffer.length < 8) return;
+        if (buffer[0] !== proto.FRAME_HEAD && buffer[0] !== proto.FRAME_HEAD_ALT) return;
+        if (buffer.readUInt16BE(4) !== dpAddress) return;
+        expected = proto.expectedResponseLength(buffer);
+      }
+      chunks.push(buffer);
+      total += buffer.length;
+      if (total >= expected) {
+        const full = Buffer.concat(chunks, total).subarray(0, expected);
+        settled = true;
+        cleanup();
+        if (!proto.verifyCrc(full)) {
+          reject(new Error("CRC mismatch"));
+          return;
+        }
+        const frame = proto.parseFrame(full);
+        if (!frame) {
+          reject(new Error("Bad frame"));
+          return;
+        }
+        resolve(frame);
+      }
+    };
+    notify.on("data", onData);
+  });
+}
+
+function writeChar(ch, buf, withResponse = false) {
+  return new Promise((resolve, reject) => {
+    ch.write(buf, !withResponse, (err) => (err ? reject(err) : resolve()));
+  });
+}
+
+async function readDP(notify, write, dpAddress, frameHead) {
+  const tx = proto.buildReadFrame(dpAddress, 0, frameHead);
+  const waiter = awaitNotification(notify, dpAddress);
+  await writeChar(write, Buffer.from(tx), false);
+  return waiter;
+}
+
+async function detectFrameHead(notify, write) {
+  for (const head of [proto.FRAME_HEAD, proto.FRAME_HEAD_ALT]) {
+    try {
+      log(`probing frame head 0x${head.toString(16)}...`);
+      await readDP(notify, write, proto.DP_PRODUCT_INFO, head);
+      log(`frame head 0x${head.toString(16)} OK`);
+      return head;
+    } catch (e) {
+      log(`head 0x${head.toString(16)} no response: ${e.message}`);
+    }
+  }
+  throw new Error("Could not detect frame head; device unresponsive");
+}
+
+function fmt(n, digits = 3) {
+  if (n == null) return "—";
+  return Number(n).toFixed(digits);
+}
+
+function dump(label, obj) {
+  console.log(`\n--- ${label} ---`);
+  console.log(JSON.stringify(obj, null, 2));
+}
+
+async function main() {
+  log(TARGET_MAC ? `looking for ${TARGET_MAC}` : "scanning for XDZN*/WT* devices");
+
+  if (noble.state !== "poweredOn") {
+    await new Promise((resolve) => {
+      const onState = (s) => {
+        if (s === "poweredOn") {
+          noble.removeListener("stateChange", onState);
+          resolve();
+        }
+      };
+      noble.on("stateChange", onState);
+    });
+  }
+
+  const peripheral = await pickPeripheral();
+  log(
+    `connecting to ${peripheral.address} (name="${peripheral.advertisement?.localName}")`
+  );
+  await new Promise((resolve, reject) =>
+    peripheral.connect((err) => (err ? reject(err) : resolve()))
+  );
+
+  try {
+    const { notify, write, auth } = await discoverChars(peripheral);
+    log("characteristics ready");
+
+    await new Promise((resolve, reject) =>
+      notify.subscribe((err) => (err ? reject(err) : resolve()))
+    );
+    log("notifications enabled on FFF1");
+
+    if (auth) {
+      try {
+        await writeChar(auth, Buffer.from(proto.AUTH_KEY), true);
+        log("auth: 'HiLink' written to FFFA");
+      } catch (e) {
+        log(`auth write failed (continuing): ${e.message}`);
+      }
+    } else {
+      log("FFFA characteristic absent; skipping auth");
+    }
+
+    const head = await detectFrameHead(notify, write);
+
+    const product = await readDP(notify, write, proto.DP_PRODUCT_INFO, head);
+    dump("Product Info (DP 0x0092)", proto.parseProductInfo(product.data));
+
+    const aqFrame = await readDP(notify, write, proto.DP_ANALOG_QUANTITY, head);
+    const aq = proto.parseAnalogQuantity(aqFrame.data);
+    dump("Analog Quantity (DP 0x008C)", aq);
+    if (aq) {
+      console.log(
+        `\n  Voltage:  ${fmt(aq.moduleVoltage, 2)} V` +
+          `   Current: ${fmt(aq.current, 2)} A` +
+          `   SOC: ${aq.soc}%` +
+          (aq.soh != null ? `   SOH: ${aq.soh}%` : "")
+      );
+      console.log(
+        `  Cells:    ${aq.cellVoltages.map((v) => fmt(v, 3)).join(" / ")} V`
+      );
+      console.log(
+        `  Temps:    MOS=${fmt(aq.mosTemperature, 1)}°C  PCB=${fmt(
+          aq.pcbTemperature,
+          1
+        )}°C  cells=[${aq.cellTemperatures.map((t) => fmt(t, 1)).join(", ")}] °C`
+      );
+      console.log(
+        `  Capacity: rem ${fmt(aq.remainingCapacity, 1)} Ah / total ${fmt(
+          aq.totalCapacity,
+          1
+        )} Ah / design ${fmt(aq.designCapacity, 1)} Ah  cycles=${aq.cycleNumber}`
+      );
+    }
+
+    const wiFrame = await readDP(notify, write, proto.DP_WARNING_INFO, head);
+    const wi = proto.parseWarningInfo(wiFrame.data);
+    dump("Warning Info (DP 0x008D)", wi);
+    if (wi) {
+      console.log(
+        `\n  protections: ${wi.protections.length ? wi.protections.join(", ") : "(none)"}`
+      );
+      console.log(
+        `  faults:      ${wi.faults.length ? wi.faults.join(", ") : "(none)"}`
+      );
+      console.log(
+        `  warnings:    ${wi.warnings.length ? wi.warnings.join(", ") : "(none)"}`
+      );
+    }
+  } finally {
+    try {
+      await new Promise((resolve) => peripheral.disconnect(() => resolve()));
+    } catch (_e) { /* ignore */ }
+    log("disconnected");
+    setTimeout(() => process.exit(0), 100);
+  }
+}
+
+main().catch((e) => fail(e.stack || e.message));

--- a/sensor_classes/wattcycle/protocol.js
+++ b/sensor_classes/wattcycle/protocol.js
@@ -1,0 +1,414 @@
+/**
+ * Wattcycle / XDZN BLE protocol: frame building, parsing, and CRC.
+ *
+ * Ported from https://github.com/qume/wattcycle_ble (Python),
+ * itself reverse-engineered from the `com.gz.wattcycle` Android APK.
+ *
+ * See sensor_classes/wattcycle/PROTOCOL.md for the protocol reference.
+ */
+
+"use strict";
+
+// --- BLE UUIDs ---
+const SERVICE_UUID = "0000fff0-0000-1000-8000-00805f9b34fb";
+const WRITE_UUID = "0000fff2-0000-1000-8000-00805f9b34fb";
+const NOTIFY_UUID = "0000fff1-0000-1000-8000-00805f9b34fb";
+const AUTH_UUID = "0000fffa-0000-1000-8000-00805f9b34fb";
+
+// --- Protocol constants ---
+const FRAME_HEAD = 0x7e;
+const FRAME_HEAD_ALT = 0x1e;
+const FRAME_TAIL = 0x0d;
+const FUNC_READ = 0x03;
+const FUNC_WRITE = 0x06;
+const FUNC_ERROR = 0x86;
+const DEVICE_ADDR = 0x01;
+const MIN_FRAME_SIZE = 11;
+
+const AUTH_KEY = Buffer.from("HiLink", "utf8");
+const DEVICE_NAME_PREFIXES = ["XDZN", "WT"];
+
+// --- DP addresses ---
+const DP_ANALOG_QUANTITY = 0x008c; // 140
+const DP_WARNING_INFO = 0x008d; // 141
+const DP_PRODUCT_INFO = 0x0092; // 146
+
+// --- Modbus CRC16 lookup tables ---
+const CRC_HI = Buffer.from([
+  0x00, 0xc1, 0x81, 0x40, 0x01, 0xc0, 0x80, 0x41, 0x01, 0xc0, 0x80, 0x41, 0x00, 0xc1, 0x81, 0x40,
+  0x01, 0xc0, 0x80, 0x41, 0x00, 0xc1, 0x81, 0x40, 0x00, 0xc1, 0x81, 0x40, 0x01, 0xc0, 0x80, 0x41,
+  0x01, 0xc0, 0x80, 0x41, 0x00, 0xc1, 0x81, 0x40, 0x00, 0xc1, 0x81, 0x40, 0x01, 0xc0, 0x80, 0x41,
+  0x00, 0xc1, 0x81, 0x40, 0x01, 0xc0, 0x80, 0x41, 0x01, 0xc0, 0x80, 0x41, 0x00, 0xc1, 0x81, 0x40,
+  0x01, 0xc0, 0x80, 0x41, 0x00, 0xc1, 0x81, 0x40, 0x00, 0xc1, 0x81, 0x40, 0x01, 0xc0, 0x80, 0x41,
+  0x00, 0xc1, 0x81, 0x40, 0x01, 0xc0, 0x80, 0x41, 0x01, 0xc0, 0x80, 0x41, 0x00, 0xc1, 0x81, 0x40,
+  0x00, 0xc1, 0x81, 0x40, 0x01, 0xc0, 0x80, 0x41, 0x01, 0xc0, 0x80, 0x41, 0x00, 0xc1, 0x81, 0x40,
+  0x01, 0xc0, 0x80, 0x41, 0x00, 0xc1, 0x81, 0x40, 0x00, 0xc1, 0x81, 0x40, 0x01, 0xc0, 0x80, 0x41,
+  0x01, 0xc0, 0x80, 0x41, 0x00, 0xc1, 0x81, 0x40, 0x00, 0xc1, 0x81, 0x40, 0x01, 0xc0, 0x80, 0x41,
+  0x00, 0xc1, 0x81, 0x40, 0x01, 0xc0, 0x80, 0x41, 0x01, 0xc0, 0x80, 0x41, 0x00, 0xc1, 0x81, 0x40,
+  0x00, 0xc1, 0x81, 0x40, 0x01, 0xc0, 0x80, 0x41, 0x01, 0xc0, 0x80, 0x41, 0x00, 0xc1, 0x81, 0x40,
+  0x01, 0xc0, 0x80, 0x41, 0x00, 0xc1, 0x81, 0x40, 0x00, 0xc1, 0x81, 0x40, 0x01, 0xc0, 0x80, 0x41,
+  0x00, 0xc1, 0x81, 0x40, 0x01, 0xc0, 0x80, 0x41, 0x01, 0xc0, 0x80, 0x41, 0x00, 0xc1, 0x81, 0x40,
+  0x01, 0xc0, 0x80, 0x41, 0x00, 0xc1, 0x81, 0x40, 0x00, 0xc1, 0x81, 0x40, 0x01, 0xc0, 0x80, 0x41,
+  0x01, 0xc0, 0x80, 0x41, 0x00, 0xc1, 0x81, 0x40, 0x00, 0xc1, 0x81, 0x40, 0x01, 0xc0, 0x80, 0x41,
+  0x00, 0xc1, 0x81, 0x40, 0x01, 0xc0, 0x80, 0x41, 0x01, 0xc0, 0x80, 0x41, 0x00, 0xc1, 0x81, 0x40,
+]);
+
+const CRC_LO = Buffer.from([
+  0x00, 0xc0, 0xc1, 0x01, 0xc3, 0x03, 0x02, 0xc2, 0xc6, 0x06, 0x07, 0xc7, 0x05, 0xc5, 0xc4, 0x04,
+  0xcc, 0x0c, 0x0d, 0xcd, 0x0f, 0xcf, 0xce, 0x0e, 0x0a, 0xca, 0xcb, 0x0b, 0xc9, 0x09, 0x08, 0xc8,
+  0xd8, 0x18, 0x19, 0xd9, 0x1b, 0xdb, 0xda, 0x1a, 0x1e, 0xde, 0xdf, 0x1f, 0xdd, 0x1d, 0x1c, 0xdc,
+  0x14, 0xd4, 0xd5, 0x15, 0xd7, 0x17, 0x16, 0xd6, 0xd2, 0x12, 0x13, 0xd3, 0x11, 0xd1, 0xd0, 0x10,
+  0xf0, 0x30, 0x31, 0xf1, 0x33, 0xf3, 0xf2, 0x32, 0x36, 0xf6, 0xf7, 0x37, 0xf5, 0x35, 0x34, 0xf4,
+  0x3c, 0xfc, 0xfd, 0x3d, 0xff, 0x3f, 0x3e, 0xfe, 0xfa, 0x3a, 0x3b, 0xfb, 0x39, 0xf9, 0xf8, 0x38,
+  0x28, 0xe8, 0xe9, 0x29, 0xeb, 0x2b, 0x2a, 0xea, 0xee, 0x2e, 0x2f, 0xef, 0x2d, 0xed, 0xec, 0x2c,
+  0xe4, 0x24, 0x25, 0xe5, 0x27, 0xe7, 0xe6, 0x26, 0x22, 0xe2, 0xe3, 0x23, 0xe1, 0x21, 0x20, 0xe0,
+  0xa0, 0x60, 0x61, 0xa1, 0x63, 0xa3, 0xa2, 0x62, 0x66, 0xa6, 0xa7, 0x67, 0xa5, 0x65, 0x64, 0xa4,
+  0x6c, 0xac, 0xad, 0x6d, 0xaf, 0x6f, 0x6e, 0xae, 0xaa, 0x6a, 0x6b, 0xab, 0x69, 0xa9, 0xa8, 0x68,
+  0x78, 0xb8, 0xb9, 0x79, 0xbb, 0x7b, 0x7a, 0xba, 0xbe, 0x7e, 0x7f, 0xbf, 0x7d, 0xbd, 0xbc, 0x7c,
+  0xb4, 0x74, 0x75, 0xb5, 0x77, 0xb7, 0xb6, 0x76, 0x72, 0xb2, 0xb3, 0x73, 0xb1, 0x71, 0x70, 0xb0,
+  0x50, 0x90, 0x91, 0x51, 0x93, 0x53, 0x52, 0x92, 0x96, 0x56, 0x57, 0x97, 0x55, 0x95, 0x94, 0x54,
+  0x9c, 0x5c, 0x5d, 0x9d, 0x5f, 0x9f, 0x9e, 0x5e, 0x5a, 0x9a, 0x9b, 0x5b, 0x99, 0x59, 0x58, 0x98,
+  0x88, 0x48, 0x49, 0x89, 0x4b, 0x8b, 0x8a, 0x4a, 0x4e, 0x8e, 0x8f, 0x4f, 0x8d, 0x4d, 0x4c, 0x8c,
+  0x44, 0x84, 0x85, 0x45, 0x87, 0x47, 0x46, 0x86, 0x82, 0x42, 0x43, 0x83, 0x41, 0x81, 0x80, 0x40,
+]);
+
+/**
+ * Modbus CRC16 using lookup tables (init 0xFF/0xFF).
+ * Result is `(lo << 8) | hi`, written big-endian into the frame.
+ *
+ * @param {Buffer|Uint8Array} data
+ * @returns {number}
+ */
+function modbusCrc16(data) {
+  let crcHi = 0xff;
+  let crcLo = 0xff;
+  for (let i = 0; i < data.length; i++) {
+    const idx = (crcHi ^ data[i]) & 0xff;
+    crcHi = (crcLo ^ CRC_HI[idx]) & 0xff;
+    crcLo = CRC_LO[idx];
+  }
+  return ((crcLo << 8) | crcHi) & 0xffff;
+}
+
+/**
+ * Build a read-command frame (old protocol, no infoData).
+ *
+ * @param {number} address DP address (e.g. DP_ANALOG_QUANTITY)
+ * @param {number} [readCount=0]
+ * @param {number} [frameHead=FRAME_HEAD]
+ * @returns {Buffer}
+ */
+function buildReadFrame(address, readCount = 0, frameHead = FRAME_HEAD) {
+  const buf = Buffer.alloc(MIN_FRAME_SIZE);
+  buf[0] = frameHead;
+  buf[1] = 0x00; // version (old protocol)
+  buf[2] = DEVICE_ADDR;
+  buf[3] = FUNC_READ;
+  buf.writeUInt16BE(address & 0xffff, 4);
+  buf.writeUInt16BE(readCount & 0xffff, 6);
+  const crc = modbusCrc16(buf.subarray(0, 8));
+  buf.writeUInt16BE(crc, 8);
+  buf[10] = FRAME_TAIL;
+  return buf;
+}
+
+/**
+ * Verify the CRC16 of a complete frame.
+ * @param {Buffer} data
+ * @returns {boolean}
+ */
+function verifyCrc(data) {
+  if (!data || data.length < MIN_FRAME_SIZE) return false;
+  const expected = data.readUInt16BE(data.length - 3);
+  return modbusCrc16(data.subarray(0, data.length - 3)) === expected;
+}
+
+/**
+ * From the first response packet, compute the total expected length
+ * (used for reassembling notifications).
+ * @param {Buffer} firstPacket
+ * @returns {number|null}
+ */
+function expectedResponseLength(firstPacket) {
+  if (!firstPacket || firstPacket.length < 8) return null;
+  return firstPacket.readUInt16BE(6) + 11;
+}
+
+/**
+ * Parse a complete response frame.
+ * Returns null on invalid frame or error response.
+ *
+ * @param {Buffer} data
+ * @returns {{
+ *   version: number,
+ *   address: number,
+ *   functionCode: number,
+ *   startAddress: number,
+ *   dataLength: number,
+ *   data: Buffer,
+ *   raw: Buffer,
+ * }|null}
+ */
+function parseFrame(data) {
+  if (!data || data.length < MIN_FRAME_SIZE) return null;
+  if (data[0] !== FRAME_HEAD && data[0] !== FRAME_HEAD_ALT) return null;
+  if (data[data.length - 1] !== FRAME_TAIL) return null;
+  const func = data[3];
+  if (func === FUNC_ERROR) return null;
+  const dataLength = data.readUInt16BE(6);
+  if (data.length < dataLength + 11) return null;
+  return {
+    version: data[1],
+    address: data[2],
+    functionCode: func,
+    startAddress: data.readUInt16BE(4),
+    dataLength,
+    data: data.subarray(8, 8 + dataLength),
+    raw: data,
+  };
+}
+
+/**
+ * Parse a 2-byte signed current (sign + decimal flag in top bits of byte 0).
+ * Bit 7: sign (1 = negative). Bit 6: decimal flag (1 = divide by 10).
+ *
+ * @param {Buffer} data
+ * @param {number} offset
+ * @returns {{ current: number, offset: number }}
+ */
+function parseCurrentNegative(data, offset) {
+  const b0 = data[offset];
+  const b1 = data[offset + 1];
+  const isNegative = (b0 & 0x80) !== 0;
+  const hasDecimal = (b0 & 0x40) !== 0;
+  const raw = b1 | ((b0 & 0x3f) << 8);
+  let current = hasDecimal ? raw / 10.0 : raw;
+  if (isNegative) current = -current;
+  return { current, offset: offset + 2 };
+}
+
+/**
+ * Parse Analog Quantity payload (DP 140 / 0x8C).
+ * `data` is the DATA portion of the frame (after header, before CRC).
+ * Returns null on parse failure.
+ *
+ * @param {Buffer} data
+ */
+function parseAnalogQuantity(data) {
+  try {
+    if (!data || data.length < 1) return null;
+    let off = 0;
+    const cellCount = data[off++];
+    const cellVoltages = [];
+    for (let i = 0; i < cellCount; i++) {
+      cellVoltages.push(data.readUInt16BE(off) / 1000.0);
+      off += 2;
+    }
+    const temperatureCount = data[off++];
+    const mosTemperature = (data.readUInt16BE(off) - 2730) / 10.0;
+    off += 2;
+    const pcbTemperature = (data.readUInt16BE(off) - 2730) / 10.0;
+    off += 2;
+    const cellTemperatures = [];
+    for (let i = 0; i < temperatureCount - 2; i++) {
+      cellTemperatures.push((data.readUInt16BE(off) - 2730) / 10.0);
+      off += 2;
+    }
+    const cur = parseCurrentNegative(data, off);
+    const current = cur.current;
+    off = cur.offset;
+    const moduleVoltage = data.readUInt16BE(off) / 100.0; off += 2;
+    const remainingCapacity = data.readUInt16BE(off) / 10.0; off += 2;
+    const totalCapacity = data.readUInt16BE(off) / 10.0; off += 2;
+    const cycleNumber = data.readUInt16BE(off); off += 2;
+    const designCapacity = data.readUInt16BE(off) / 10.0; off += 2;
+    const soc = data.readUInt16BE(off); off += 2;
+
+    const out = {
+      cellCount,
+      cellVoltages,
+      temperatureCount,
+      mosTemperature,
+      pcbTemperature,
+      cellTemperatures,
+      current,
+      moduleVoltage,
+      remainingCapacity,
+      totalCapacity,
+      cycleNumber,
+      designCapacity,
+      soc,
+      soh: null,
+      cumulativeCapacity: null,
+      remainingTimeMin: null,
+      balanceCurrent: null,
+    };
+
+    // New-version extension (>= 18 bytes remaining)
+    if (data.length - off >= 18) {
+      out.soh = data.readUInt16BE(off); off += 2;
+      out.cumulativeCapacity = data.readUInt32BE(off) / 10.0; off += 4;
+      out.remainingTimeMin = data.readInt32BE(off); off += 4;
+      off += 6; // 3 reserved uint16
+      const bal = parseCurrentNegative(data, off);
+      out.balanceCurrent = bal.current;
+    }
+
+    return out;
+  } catch (_e) {
+    return null;
+  }
+}
+
+/**
+ * Parse Product Info payload (DP 146 / 0x92).
+ * Expects exactly 60 bytes.
+ *
+ * @param {Buffer} data
+ */
+function parseProductInfo(data) {
+  if (!data || data.length !== 60) return null;
+  const decode = (slice) =>
+    slice.toString("ascii").replace(/ +$/g, "").trim();
+  return {
+    firmwareVersion: decode(data.subarray(0, 20)),
+    manufacturerName: decode(data.subarray(20, 40)),
+    serialNumber: decode(data.subarray(40, 60)),
+  };
+}
+
+const PROTECTION_BITS_R1 = [
+  "cell_overcharge",
+  "cell_overdischarge",
+  "total_overcharge",
+  "total_overdischarge",
+  "charge_overcurrent",
+  "discharge_overcurrent",
+  "hardware",
+  "charge_voltage_high",
+];
+const PROTECTION_BITS_R2 = [
+  "charge_high_temp",
+  "discharge_high_temp",
+  "charge_low_temp",
+  "discharge_low_temp",
+  "mos_high_temp",
+  "env_high_temp",
+  "env_low_temp",
+];
+const FAULT_BITS_R5 = ["cell", "charge_mos", "discharge_mos", "temperature"];
+
+function bitsToFlags(byte, names) {
+  const flags = [];
+  for (let i = 0; i < names.length; i++) {
+    if ((byte & (1 << i)) !== 0) flags.push(names[i]);
+  }
+  return flags;
+}
+
+/**
+ * Parse Warning Info payload (DP 141 / 0x8D).
+ *
+ * @param {Buffer} data
+ */
+function parseWarningInfo(data) {
+  try {
+    if (!data || data.length < 1) return null;
+    let off = 0;
+    const cellCount = data[off++];
+    const cellStates = [];
+    for (let i = 0; i < cellCount; i++) cellStates.push(data[off++]);
+
+    const temperatureCount = data[off++];
+    const mosTemperatureState = data[off++];
+    const pcbTemperatureState = data[off++];
+    const cellTempStates = [];
+    for (let i = 0; i < temperatureCount - 2; i++) cellTempStates.push(data[off++]);
+
+    const chargeCurrentState = data[off++];
+    const voltageState = data[off++];
+    const dischargeCurrentState = data[off++];
+    const batteryMode = data[off++];
+    const statusRegister1 = data[off++];
+    const statusRegister2 = data[off++];
+    const statusRegister3 = data[off++];
+    off++; // reserved
+    const statusRegister5 = data[off++];
+    off += 2; // reserved
+    const warningRegister1 = data[off++];
+    const warningRegister2 = data[off++];
+
+    const balanceStates = [];
+    const nBytes = Math.ceil(cellCount / 8);
+    for (let i = 0; i < nBytes; i++) {
+      const byteVal = data[off++];
+      for (let bit = 0; bit < 8; bit++) {
+        const idx = i * 8 + bit;
+        if (idx < cellCount) balanceStates.push((byteVal & (1 << bit)) !== 0);
+      }
+    }
+
+    return {
+      cellCount,
+      cellStates,
+      temperatureCount,
+      mosTemperatureState,
+      pcbTemperatureState,
+      cellTempStates,
+      chargeCurrentState,
+      voltageState,
+      dischargeCurrentState,
+      batteryMode,
+      statusRegister1,
+      statusRegister2,
+      statusRegister3,
+      statusRegister5,
+      warningRegister1,
+      warningRegister2,
+      balanceStates,
+      protections: [
+        ...bitsToFlags(statusRegister1, PROTECTION_BITS_R1),
+        ...bitsToFlags(statusRegister2, PROTECTION_BITS_R2),
+      ],
+      faults: bitsToFlags(statusRegister5, FAULT_BITS_R5),
+      warnings: [
+        ...bitsToFlags(warningRegister1, PROTECTION_BITS_R1),
+        ...bitsToFlags(warningRegister2, PROTECTION_BITS_R2),
+      ],
+    };
+  } catch (_e) {
+    return null;
+  }
+}
+
+module.exports = {
+  // UUIDs
+  SERVICE_UUID,
+  WRITE_UUID,
+  NOTIFY_UUID,
+  AUTH_UUID,
+  // constants
+  FRAME_HEAD,
+  FRAME_HEAD_ALT,
+  FRAME_TAIL,
+  FUNC_READ,
+  FUNC_WRITE,
+  FUNC_ERROR,
+  DEVICE_ADDR,
+  MIN_FRAME_SIZE,
+  AUTH_KEY,
+  DEVICE_NAME_PREFIXES,
+  DP_ANALOG_QUANTITY,
+  DP_WARNING_INFO,
+  DP_PRODUCT_INFO,
+  // functions
+  modbusCrc16,
+  buildReadFrame,
+  verifyCrc,
+  expectedResponseLength,
+  parseFrame,
+  parseCurrentNegative,
+  parseAnalogQuantity,
+  parseProductInfo,
+  parseWarningInfo,
+};

--- a/spec/wattcycle_protocol.test.js
+++ b/spec/wattcycle_protocol.test.js
@@ -1,0 +1,239 @@
+/**
+ * Tests for the WattCycle protocol module.
+ * Run with: node --test spec/wattcycle_protocol.test.js
+ *
+ * Captured fixtures are taken verbatim from the upstream wattcycle_ble
+ * Python project (tests/test_protocol.py) - real device traffic from
+ * an XDZN_001_EF2F unit.
+ */
+
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const {
+  DP_ANALOG_QUANTITY,
+  DP_PRODUCT_INFO,
+  DP_WARNING_INFO,
+  modbusCrc16,
+  buildReadFrame,
+  verifyCrc,
+  expectedResponseLength,
+  parseFrame,
+  parseCurrentNegative,
+  parseAnalogQuantity,
+  parseProductInfo,
+  parseWarningInfo,
+} = require("../sensor_classes/wattcycle/protocol.js");
+
+const SAMPLE_WARNING = Buffer.from([
+  0x7e, 0x00, 0x01, 0x03, 0x00, 0x8d, 0x00, 0x18,
+  0x04, 0x00, 0x00, 0x00, 0x00, 0x04, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x06, 0x01, 0x00, 0x00, 0x18, 0x00, 0x00, 0x00,
+  0x1f, 0x91, 0x0d,
+]);
+
+const SAMPLE_ANALOG = Buffer.from([
+  0x7e, 0x00, 0x01, 0x03, 0x00, 0x8c, 0x00, 0x20,
+  0x04, 0x0c, 0xde, 0x0c, 0xdd, 0x0c, 0xdf, 0x0c,
+  0xda, 0x04, 0x0b, 0x65, 0x0b, 0x70, 0x0b, 0x5a,
+  0x0b, 0x5a, 0x40, 0x00, 0x05, 0x25, 0x07, 0x2a,
+  0x0c, 0x44, 0x00, 0x05, 0x0c, 0x44, 0x00, 0x3a,
+  0x4b, 0x22, 0x0d,
+]);
+
+const SAMPLE_PRODUCT = Buffer.from([
+  0x7e, 0x00, 0x01, 0x03, 0x00, 0x92, 0x00, 0x3c,
+  0x57, 0x54, 0x31, 0x32, 0x5f, 0x32, 0x30, 0x30,
+  0x30, 0x34, 0x53, 0x57, 0x31, 0x30, 0x5f, 0x4c,
+  0x34, 0x34, 0x37, 0x00, 0x20, 0x20, 0x20, 0x20,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x36, 0x30, 0x30, 0x31, 0x36, 0x30, 0x31, 0x36,
+  0x32, 0x30, 0x37, 0x32, 0x37, 0x30, 0x30, 0x30,
+  0x31, 0x00, 0x00, 0x00,
+  0x52, 0xaa, 0x0d,
+]);
+
+test("modbusCrc16: matches captured warning payload CRC", () => {
+  const payload = SAMPLE_WARNING.subarray(0, SAMPLE_WARNING.length - 3);
+  assert.equal(modbusCrc16(payload), 0x1f91);
+});
+
+test("modbusCrc16: matches captured analog payload CRC", () => {
+  const payload = SAMPLE_ANALOG.subarray(0, SAMPLE_ANALOG.length - 3);
+  const expected = SAMPLE_ANALOG.readUInt16BE(SAMPLE_ANALOG.length - 3);
+  assert.equal(modbusCrc16(payload), expected);
+});
+
+test("modbusCrc16: matches captured product payload CRC", () => {
+  const payload = SAMPLE_PRODUCT.subarray(0, SAMPLE_PRODUCT.length - 3);
+  const expected = SAMPLE_PRODUCT.readUInt16BE(SAMPLE_PRODUCT.length - 3);
+  assert.equal(modbusCrc16(payload), expected);
+});
+
+test("modbusCrc16: empty input does not throw", () => {
+  assert.equal(typeof modbusCrc16(Buffer.alloc(0)), "number");
+});
+
+test("buildReadFrame: analog-quantity request matches spec", () => {
+  const frame = buildReadFrame(DP_ANALOG_QUANTITY);
+  assert.equal(frame[0], 0x7e);
+  assert.equal(frame[1], 0x00);
+  assert.equal(frame[2], 0x01);
+  assert.equal(frame[3], 0x03);
+  assert.equal(frame.readUInt16BE(4), 0x008c);
+  assert.equal(frame.readUInt16BE(6), 0);
+  assert.equal(frame[10], 0x0d);
+  assert.equal(frame.length, 11);
+});
+
+test("buildReadFrame: warning-info & product-info DP addresses", () => {
+  assert.equal(buildReadFrame(DP_WARNING_INFO).readUInt16BE(4), 0x008d);
+  assert.equal(buildReadFrame(DP_PRODUCT_INFO).readUInt16BE(4), 0x0092);
+});
+
+test("buildReadFrame: alternative frame head 0x1E", () => {
+  const frame = buildReadFrame(DP_ANALOG_QUANTITY, 0, 0x1e);
+  assert.equal(frame[0], 0x1e);
+  assert.equal(frame[10], 0x0d);
+  assert.ok(verifyCrc(frame));
+});
+
+test("verifyCrc: real frames pass; corrupted/short frames fail", () => {
+  assert.ok(verifyCrc(SAMPLE_WARNING));
+  assert.ok(verifyCrc(SAMPLE_ANALOG));
+  assert.ok(verifyCrc(SAMPLE_PRODUCT));
+
+  const bad = Buffer.from(SAMPLE_WARNING);
+  bad[10] ^= 0xff;
+  assert.equal(verifyCrc(bad), false);
+
+  assert.equal(verifyCrc(Buffer.from([0x7e, 0x00, 0x01])), false);
+});
+
+test("expectedResponseLength: derives total length from data_len field", () => {
+  // SAMPLE_WARNING: data_len = 0x18 (24), total = 24 + 11 = 35
+  assert.equal(expectedResponseLength(SAMPLE_WARNING), 35);
+  assert.equal(expectedResponseLength(Buffer.alloc(4)), null);
+});
+
+test("parseFrame: warning frame metadata", () => {
+  const f = parseFrame(SAMPLE_WARNING);
+  assert.ok(f);
+  assert.equal(f.version, 0);
+  assert.equal(f.address, 1);
+  assert.equal(f.functionCode, 0x03);
+  assert.equal(f.startAddress, 0x8d);
+  assert.equal(f.dataLength, 24);
+  assert.equal(f.data.length, 24);
+});
+
+test("parseFrame: error response (func 0x86) returns null", () => {
+  const bad = Buffer.from(SAMPLE_WARNING);
+  bad[3] = 0x86;
+  assert.equal(parseFrame(bad), null);
+});
+
+test("parseFrame: bad head/tail/short returns null", () => {
+  const badHead = Buffer.from(SAMPLE_WARNING);
+  badHead[0] = 0xff;
+  assert.equal(parseFrame(badHead), null);
+
+  const badTail = Buffer.from(SAMPLE_WARNING);
+  badTail[badTail.length - 1] = 0xff;
+  assert.equal(parseFrame(badTail), null);
+
+  assert.equal(parseFrame(Buffer.from([0x7e, 0x00])), null);
+});
+
+test("parseCurrentNegative: zero", () => {
+  const r = parseCurrentNegative(Buffer.from([0x00, 0x00]), 0);
+  assert.equal(r.current, 0);
+  assert.equal(r.offset, 2);
+});
+
+test("parseCurrentNegative: positive with decimal flag", () => {
+  // 0x40 = decimal, 0x64 = 100 -> 10.0
+  assert.equal(parseCurrentNegative(Buffer.from([0x40, 0x64]), 0).current, 10.0);
+});
+
+test("parseCurrentNegative: negative with decimal flag", () => {
+  // 0xC0 = sign+decimal, 0x64 = 100 -> -10.0
+  assert.equal(parseCurrentNegative(Buffer.from([0xc0, 0x64]), 0).current, -10.0);
+});
+
+test("parseCurrentNegative: positive integer (no decimal)", () => {
+  assert.equal(parseCurrentNegative(Buffer.from([0x00, 0x0a]), 0).current, 10.0);
+});
+
+test("parseCurrentNegative: negative integer (no decimal)", () => {
+  assert.equal(parseCurrentNegative(Buffer.from([0x80, 0x0a]), 0).current, -10.0);
+});
+
+test("parseCurrentNegative: 102.3 A boundary", () => {
+  // 0x43 0xFF -> decimal, raw = 0xFF | (0x03 << 8) = 1023 -> 102.3
+  const r = parseCurrentNegative(Buffer.from([0x43, 0xff]), 0);
+  assert.ok(Math.abs(r.current - 102.3) < 0.01);
+});
+
+test("parseAnalogQuantity: real captured response decodes correctly", () => {
+  const f = parseFrame(SAMPLE_ANALOG);
+  assert.ok(f);
+  const aq = parseAnalogQuantity(f.data);
+  assert.ok(aq);
+
+  assert.equal(aq.cellCount, 4);
+  assert.equal(aq.cellVoltages.length, 4);
+  assert.ok(Math.abs(aq.cellVoltages[0] - 3.294) < 0.001);
+  assert.ok(Math.abs(aq.cellVoltages[3] - 3.290) < 0.001);
+
+  assert.equal(aq.temperatureCount, 4);
+  assert.ok(Math.abs(aq.mosTemperature - 18.7) < 0.1);
+  assert.ok(Math.abs(aq.pcbTemperature - 19.8) < 0.1);
+  assert.equal(aq.cellTemperatures.length, 2);
+  assert.ok(Math.abs(aq.cellTemperatures[0] - 17.6) < 0.1);
+
+  assert.equal(aq.current, 0);
+  assert.ok(Math.abs(aq.moduleVoltage - 13.17) < 0.01);
+  assert.ok(Math.abs(aq.remainingCapacity - 183.4) < 0.1);
+  assert.ok(Math.abs(aq.totalCapacity - 314.0) < 0.1);
+  assert.equal(aq.cycleNumber, 5);
+  assert.ok(Math.abs(aq.designCapacity - 314.0) < 0.1);
+  assert.equal(aq.soc, 58);
+});
+
+test("parseAnalogQuantity: short / empty input returns null", () => {
+  assert.equal(parseAnalogQuantity(Buffer.alloc(0)), null);
+  assert.equal(parseAnalogQuantity(Buffer.from([0x04])), null);
+});
+
+test("parseProductInfo: real captured response decodes ASCII", () => {
+  const f = parseFrame(SAMPLE_PRODUCT);
+  const pi = parseProductInfo(f.data);
+  assert.ok(pi);
+  assert.equal(pi.firmwareVersion, "WT12_20004SW10_L447");
+  assert.equal(pi.serialNumber, "60016016207270001");
+});
+
+test("parseProductInfo: wrong length returns null", () => {
+  assert.equal(parseProductInfo(Buffer.alloc(30)), null);
+});
+
+test("parseWarningInfo: real captured response decodes; no flags set", () => {
+  const f = parseFrame(SAMPLE_WARNING);
+  const wi = parseWarningInfo(f.data);
+  assert.ok(wi);
+  assert.equal(wi.cellCount, 4);
+  assert.equal(wi.cellStates.length, 4);
+  assert.equal(wi.temperatureCount, 4);
+  assert.deepEqual(wi.protections, []);
+  assert.deepEqual(wi.faults, []);
+  assert.deepEqual(wi.warnings, []);
+});
+
+test("parseWarningInfo: empty input returns null", () => {
+  assert.equal(parseWarningInfo(Buffer.alloc(0)), null);
+});


### PR DESCRIPTION
## Summary

Adds a sensor class for **WattCycle / XDZN / WT** LiFePO4 BMS devices.
These batteries expose a BLE BMS on service `0xFFF0` with the
\"WATT\" protocol (Modbus-like framing + CRC16 + a `HiLink` auth
write to characteristic `FFFA`).

- `sensor_classes/WattCycleBMS.js` — GATT-connected sensor:
  - performs the `HiLink` auth handshake on connect
  - autodetects the frame head (`0x7E`, falling back to `0x1E`)
  - polls Analog Quantity (`0x008C`), Warning Info (`0x008D`),
    and one-shot Product Info (`0x0092`)
  - emits to standard SignalK paths under
    `electrical.batteries.{batteryID}.*` (voltage, current, SOC,
    SOH, capacity remaining/actual/nominal, cycles, per-cell
    voltage/balance, temperatures, protectionStatus)
- `sensor_classes/wattcycle/protocol.js` — pure-JS port of the
  framing, Modbus CRC16 lookup tables, frame builder, parsers, and
  the new-version analog-quantity extension (SOH /
  cumulativeCapacity / remainingTime / balanceCurrent).
- `spec/wattcycle_protocol.test.js` — 24 \`node:test\` cases that
  decode real frames captured from an XDZN_001_EF2F unit
  (firmware `WT12_20004SW10_L447`).
- `README.md` — WattCycle entry added to the Electrical table.

## Origin & attribution

Protocol port from
[qume/wattcycle_ble](https://github.com/qume/wattcycle_ble) (MIT,
(c) 2025 Luke), itself reverse-engineered from the
`com.gz.wattcycle` Android APK with `jadx`. Full attribution is
in `sensor_classes/wattcycle/NOTICE.md`. Parser invariants are
locked in by tests against captured fixtures from the upstream
project.

## How to verify

\`\`\`bash
node --test spec/wattcycle_protocol.test.js
# 24/24 pass on Node 22.x
\`\`\`

## Test plan

- [x] CRC16, frame build, frame parse — covered by 24 unit tests
      against real captured data
- [x] Pure-JS protocol port verified parser-equivalent with the
      Python reference
- [ ] **Hardware validation pending** — PR opened as **draft** until
      I can run the branch on a Raspberry Pi against a real
      WattCycle 12V LiFePO4 battery (own one, not yet exercised).
      Will undraft once readings are confirmed against the official
      app.
- [ ] Long-running connection stability (poll / reconnect cycle)

## Notes

- No image asset (`static ImageFile`) is set yet; happy to add one
  if there's a preferred source.
- The class assumes one battery per BLE peripheral; multi-battery
  packs that share a single MAC haven't been considered.