### PR TITLE
Fix runtime ReferenceErrors and crash-on-data in 8 files

### DIFF
--- a/classLoader.js
+++ b/classLoader.js
@@ -38,7 +38,7 @@ const semver = require('semver')
                         const cls = require(module.location+module.module+"/"+classFile);
                         classMap.set(cls.name, cls);
                     } catch (e) {
-                        console.log(`Unable to load classfile (${file}): ${e.message}`)
+                        console.log(`Unable to load classfile (${classFile}): ${e.message}`)
                         console.log(e)
                     }
                 })

--- a/sensor_classes/BTHome/AbstractBTHomeSensor.js
+++ b/sensor_classes/BTHome/AbstractBTHomeSensor.js
@@ -243,6 +243,7 @@ class AbstractBTHomeSensor extends BTSensor {
 			btHomeData,
 			BTHomeServiceData.BthomeObjectId.BINARY_MOTION
 		)?.motion;
+		if (!motion) return null;
 		return motion.intValue==1
 	}
 	
@@ -256,7 +257,7 @@ class AbstractBTHomeSensor extends BTSensor {
 		return this.getSensorDataByObjectId(
 			btHomeData,
 			BTHomeServiceData.BthomeObjectId.MISC_PACKET_ID,
-		).packetId
+		)?.packetId ?? null
 	}
 
 	/**
@@ -312,6 +313,7 @@ class AbstractBTHomeSensor extends BTSensor {
    */
   parseWindowState(btHomeData) {
     const state = this.getSensorDataByObjectId(btHomeData, BTHomeServiceData.BthomeObjectId.BINARY_WINDOW)?.window;
+    if (!state) return null;
     if (state.intValue === 1) return "open";
     if (state.intValue === 0) return "closed";
     return null;

--- a/sensor_classes/Junctek.js
+++ b/sensor_classes/Junctek.js
@@ -109,7 +109,7 @@ class JunctekBMS extends BTSensor{
                     emitObject["charge"]=v/100000
                     break
                 case 0xD6:
-                    if (chargeDirection==-1){
+                    if (this.chargeDirection==-1){
                         emitObject["timeToCharged"] = NaN
                         emitObject["timeRemaining"] = v*60
                     }

--- a/sensor_classes/KilovaultHLXPlus.js
+++ b/sensor_classes/KilovaultHLXPlus.js
@@ -194,9 +194,9 @@ class KilovaultHLXPlus extends BTSensor{
       }
     }
 
-    async initGATTConnection(isReconnecting){ 
+    async initGATTConnection(isReconnecting){
         await super.initGATTConnection(isReconnecting)
-        const gattServer= this.getGATTServer()
+        const gattServer= await this.getGATTServer()
         
         const battService = await gattServer.getPrimaryService("0000ffe0-0000-1000-8000-00805f9b34fb") 
         this.battCharacteristic = await battService.getCharacteristic("0000ffe4-0000-1000-8000-00805f9b34fb")

--- a/sensor_classes/RemoranWave3.js
+++ b/sensor_classes/RemoranWave3.js
@@ -59,7 +59,8 @@ const BTSensor = require("../BTSensor");
             this.debug(`Bad buffer size ${buffer.length}. Buffer size must be 20 bytes or more.`)
             return
         }
-        this.emit("versionNumber", buffer.readUInt8(0))
+        const versionNumber = buffer.readUInt8(0)
+        this.emit("versionNumber", versionNumber)
         const errors = buffer.readUInt8(2)
         const errorState = []
         for (var i = 0; i < 8; ++i) {
@@ -76,7 +77,7 @@ const BTSensor = require("../BTSensor");
         if (buffer.length > 23) {
             this.emit( "temp", ((buffer.readFloatLE(20))+273.15))
             this.emit( "uptime", buffer.readUInt32LE(24))
-            if (versionNumber>1 && buffer.size > 31) {
+            if (versionNumber>1 && buffer.length > 31) {
                 this.emit("energy", buffer.readFloatLE(32))
             }
         }
@@ -84,7 +85,7 @@ const BTSensor = require("../BTSensor");
     }
     emitInfo2Data(buffer){
 
-        if (buffer.size < 12) {
+        if (buffer.length < 12) {
             this.setError(`Bad buffer size ${buffer.length}. Buffer size must be 12 bytes or more.`)
             return
          }

--- a/sensor_classes/RuuviTag.js
+++ b/sensor_classes/RuuviTag.js
@@ -104,10 +104,10 @@ Offset	Allowed values	Description
         this.addDefaultPath("pressure", "environment.pressure") 
         .read=(buffer)=>{ return buffer.readUInt16BE(4)+50000}
         
-        this.addMetadatum("accX","Mg","acceleration on X-axis", 
+        this.addMetadatum("accX","Mg","acceleration on X-axis",
             (buffer)=>{ return buffer.readInt16BE(6)}
-        ).
-        this.addMetadatum("accY","Mg","acceleration on Y-axis", 
+        )
+        this.addMetadatum("accY","Mg","acceleration on Y-axis",
             (buffer)=>{ return buffer.readInt16BE(8)}
         )
         this.addMetadatum("accZ","Mg","acceleration on Z-axis", 

--- a/sensor_classes/SwitchBotMeterPlus.js
+++ b/sensor_classes/SwitchBotMeterPlus.js
@@ -50,15 +50,15 @@ class SwitchBotMeterPlus extends BTSensor{
     }
 
     propertiesChanged(props){
-        super.propertiesChanged(props)    
+        super.propertiesChanged(props)
+        if (!props.ServiceData) return
         const buff = this.getServiceData("0000fd3d-0000-1000-8000-00805f9b34fb")
-        if (!buff)
-            throw new Error("Unable to get service data for "+this.getDisplayName())
+        if (!buff) return
         this.emitData("temp", buff)
         this.emitData("humidity", buff)
         this.emitData("battery", buff)
-        
-    }                    
+
+    }
     getManufacturer(){
         return "Wonder Labs"
     }

--- a/sensor_classes/WT901BLE.js
+++ b/sensor_classes/WT901BLE.js
@@ -214,7 +214,7 @@ class WT901BLE extends   WT901Sensor {
       }
 
       async emitGATT(){
-        this.debug(`in emitGATT, pollfreq: ${pollfreq}`)
+        this.debug(`in emitGATT, pollfreq: ${this?.pollFreq}`)
         //await this.emitGATT2()
       }
       async emitGATT2(){


### PR DESCRIPTION
## Summary

Each of these is a latent runtime crash that fires the moment the affected code path runs — sensor data arrives, GATT init runs, etc. They look like simple typos or copy-paste residue but each one breaks the affected sensor entirely.

- **`WT901BLE.emitGATT`** — bare `pollfreq` (lowercase) instead of `this.pollFreq`; ReferenceError on every poll.
- **`Junctek` case 0xD6** — bare `chargeDirection` instead of `this.chargeDirection`; ReferenceError on the time-remaining branch.
- **`RemoranWave3.emitInfo1Data`** — bare `versionNumber` (now captured into a local at the top); also `buffer.size` (doesn't exist on Node Buffer) → `buffer.length` in two places.
- **`classLoader.js` catch block** — referenced undefined `file` (loop var is `classFile`); any third-party class load failure threw a fresh ReferenceError that masked the real error.
- **`KilovaultHLXPlus.initGATTConnection`** — `getGATTServer()` called without `await`; the next `.getPrimaryService(...)` ran on a Promise and threw.
- **`RuuviTag.initSchema`** — stray `.` between two `addMetadatum(...)` calls; the assignment evaluates to a string, so `'string'.this.addMetadatum(...)` throws.
- **`SwitchBotMeterPlus.propertiesChanged`** — called `getServiceData(...)` on RSSI-only events (no `ServiceData` property) and threw. Added the same `ServiceData` guard the sibling `SwitchBotTH` already uses.
- **`AbstractBTHomeSensor` parsers** — `parseMotion`, `parseWindowState`, `parsePacketID` dereferenced `.intValue` / `.packetId` on a possibly-missing object with no guard. `parseButton` (in the same file) shows the correct null-guarded pattern.

## Test plan

- [ ] Confirm `WT901BLE`, `Junctek`, `RemoranWave3`, `KilovaultHLXPlus` poll/emit without throwing.
- [ ] Confirm a `RuuviTag` sensor instantiates without throwing in `initSchema`.
- [ ] Confirm `SwitchBotMeterPlus` does not crash on RSSI-only events.
- [ ] Confirm `ShellySBDW002C` (window state) and any motion BTHome sensor do not crash when their optional object IDs are absent.
- [ ] Confirm classLoader logs a sensible message when a third-party class fails to load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)