### PR TITLE
Fix connection-lifecycle leaks and broken state

### DIFF
--- a/BTSensor.js
+++ b/BTSensor.js
@@ -565,22 +565,23 @@ class BTSensor extends EventEmitter {
         return this?._connected??false
     }
     async connectDevice( isReconnecting, retries=5, retryInterval=3){
+        let lastError;
         for (let attempts = 0; attempts<retries; attempts++) {
-            try 
-            { 
+            try
+            {
                 this.debug( `Trying to connect (attempt # ${attempts +1}) to Bluetooth device.` );
                 await this.deviceConnect(isReconnecting);
                 return this.device
             }
 
             catch (e){
-                if (attempts==retries)
-                    throw new Error (`(${this.getName}) Unable to connect to Bluetooth device after ${attempts} attempts`)
+                lastError = e;
                 this.debug(`Error connecting to device. Retrying... `);
                 await new Promise((r) => setTimeout(r, retryInterval*1000));
 
             }
         }
+        throw new Error(`(${this.getName()}) Unable to connect to Bluetooth device after ${retries} attempts: ${lastError?.message}`)
     }
     setConnected(state){
         this._connected=state

--- a/index.js
+++ b/index.js
@@ -275,10 +275,11 @@ module.exports =   function (app) {
 					options, async () => {
 						res.status(200).json({message: "Sensor updated"})
 						if (sensor) {
-							if (sensor.isActive()) 
+							if (sensor.isActive()) {
 								await sensor.stopListening()
 								removeSensorFromList(sensor)
-						} 
+							}
+						}
 						initConfiguredDevice(req.body)
 					}
 				)
@@ -734,12 +735,11 @@ module.exports =   function (app) {
 			plugin.setError(`Unable to get adapters: ${e.message}`)
 		}
 		
-		await startScanner(options)
 		if (starts>0){
 			plugin.debug(`Plugin ${packageInfo.version} restarting...`);
 		} else {
 			plugin.debug(`Plugin ${packageInfo.version} started` )
-			
+
 		}
 		starts++
 		if (!await adapter.isDiscovering())
@@ -753,16 +753,16 @@ module.exports =   function (app) {
 			const totalDevices = deviceConfigs.filter((dc)=>dc.active).length
 
 			var progress = 0
-			if (progressID==null) 
+			if (progressID==null)
 			progressID  = setInterval(()=>{
 				channel.broadcast({"progress":++progress, "maxTimeout": maxTimeout, "deviceCount":foundConfiguredDevices, "totalDevices": totalDevices},"progress")
 				if ( foundConfiguredDevices==totalDevices){
-					progressID,progressTimeoutID = null
-					clearTimeout(progressTimeoutID)
+					if (progressTimeoutID) clearTimeout(progressTimeoutID)
+					progressTimeoutID = null
 					clearInterval(progressID)
 					progressID = null
 				}
-			},1000); 
+			},1000);
 			if (progressTimeoutID==null)
 			progressTimeoutID = setTimeout(()=> {
 				if (progressID) {
@@ -836,7 +836,7 @@ module.exports =   function (app) {
 		}
 
 		if (deviceHealthID) {
-			clearTimeout(deviceHealthID)
+			clearInterval(deviceHealthID)
 			deviceHealthID=null
 		}
 

--- a/sensor_classes/HumsienkBMS.js
+++ b/sensor_classes/HumsienkBMS.js
@@ -222,13 +222,11 @@ class HumsienkBMS extends BTSensor {
     } catch (e) {
       this.debug(`Failed to emit battery info for ${this.getName()}: ${e}`);
     }
-    setTimeout(async () => {
-      try {
-        await this.getAndEmitCellVoltages();
-      } catch (e) {
-        this.debug(`Failed to emit cell voltages for ${this.getName()}: ${e}`);
-      }
-    }, 10000);
+    try {
+      await this.getAndEmitCellVoltages();
+    } catch (e) {
+      this.debug(`Failed to emit cell voltages for ${this.getName()}: ${e}`);
+    }
   }
 
   /**

--- a/sensor_classes/MercurySmartcraft.js
+++ b/sensor_classes/MercurySmartcraft.js
@@ -107,7 +107,7 @@ class MercurySmartcraft extends BTSensor{
     }
     async deactivateGATT(){
         for (const c in this.dataCharacteristics){
-            await this.stopGATTNotifications(c)
+            await this.stopGATTNotifications(this.dataCharacteristics[c])
         }
         await super.deactivateGATT()
 

--- a/sensor_classes/ShellySBWS90CM.js
+++ b/sensor_classes/ShellySBWS90CM.js
@@ -214,6 +214,7 @@ class ShellySBWS90CM extends AbstractBTHomeSensor {
   }
 
   propertiesChanged(props) {
+    super.propertiesChanged(props);
     const raw = this.getServiceData(this.constructor.BTHOME_SERVICE_ID);
     if (!raw) return;
     const buffer = Buffer.isBuffer(raw) ? raw : Buffer.from(raw);


### PR DESCRIPTION
## Summary

These all degrade across reconnect or restart instead of crashing on first run, which is why they have stayed latent.

- **`BTSensor.connectDevice`** — the retry loop checked `if (attempts == retries)` *inside* the catch, but the loop's own condition exits at `attempts == retries`, so the guard never fired. After 5 failed attempts the function returned `undefined` and callers assumed success. Now tracks the last error and throws with a meaningful message after the loop.
- **`index.js` `/updateSensorData`** — missing braces meant `removeSensorFromList(sensor)` ran even when `sensor.isActive()` was false and `stopListening()` was deliberately skipped. That removed the sensor from the map while `initConfiguredDevice(req.body)` was about to re-add it under the same MAC.
- **`index.js` progress timer** — `progressID, progressTimeoutID = null` is a comma expression that only assigns to `progressTimeoutID`; the subsequent `clearTimeout(progressTimeoutID)` was therefore a no-op (the id had just been nulled).
- **`index.js` `plugin.stop`** — `clearTimeout(deviceHealthID)` but `deviceHealthID` was set with `setInterval`, so the health-check interval kept firing after the plugin stopped.
- **`index.js` `plugin.start`** — `startScanner(options)` was called unconditionally on line ~737 *and* again inside `if (!await adapter.isDiscovering())`. Removed the unconditional call; the conditional one stays as the actual gate.
- **`MercurySmartcraft.deactivateGATT`** — `for (const c in this.dataCharacteristics)` iterates string keys; the loop body passed `c` (the key) to `stopGATTNotifications` instead of `this.dataCharacteristics[c]`. Notifications were never cleaned up; listeners leaked on every disconnect.
- **`ShellySBWS90CM.propertiesChanged`** — override did not call `super.propertiesChanged(props)`, breaking RSSI and connected-state tracking that `AbstractBTHomeSensor` and `BTSensor` rely on. Added the super call as the first line.
- **`HumsienkBMS.emitGATT`** — fired `getAndEmitCellVoltages` via a 10s `setTimeout` while the poll interval was already running, so two BLE command sequences could overlap on the same characteristic and corrupt the `getBuffer` reassembly. Replaced with sequential `await`.

I also reviewed `BTSensor.deviceConnect`'s connect/disconnect listeners; they are guarded by `if (!isReconnecting)` and do not actually compound on reconnect, contrary to my earlier note. Skipping that one.

I also did **not** include the `HumsienkBMS.initGATTInterval` duplicate-GATT-init claim — that file is on this codebase's active fix branch and I did not want to override in-progress work.

## Test plan

- [ ] Trigger a sensor that fails to connect 5 times and confirm a meaningful error surfaces (rather than silent success).
- [ ] Update a *deactivated* sensor via `/updateSensorData` and confirm the sensor is not removed from the map mid-update.
- [ ] Stop the plugin and confirm the device-health interval stops firing.
- [ ] Restart the plugin and confirm only one `StartDiscovery` D-Bus call per restart.
- [ ] Trigger a `MercurySmartcraft` disconnect/reconnect cycle and confirm `valuechanged` listener count stays stable.
- [ ] Verify `ShellySBWS90CM` reports RSSI and connected-state through the SSE channel.
- [ ] Run the HSC14F poll loop continuously and confirm no overlapping `getBuffer` errors in the log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)