### PR TITLE
feat: select Bluetooth adapter by MAC address

### DIFF
--- a/MissingAdapter.js
+++ b/MissingAdapter.js
@@ -1,0 +1,24 @@
+const EventEmitter = require('node:events')
+
+class MissingAdapter {
+    constructor(adapterID) {
+        this.adapter = adapterID
+        this.helper = {
+            _propsProxy: new EventEmitter(),
+            _prepare: async () => {},
+            callMethod: async () => {}
+        }
+    }
+    async isPowered() { return false }
+    async isDiscovering() { return true }
+    async devices() { return [] }
+    async waitDevice(_mac, timeoutMs) {
+        return new Promise((_, reject) =>
+            setTimeout(() => reject(new Error('No Bluetooth adapter available')), timeoutMs)
+        )
+    }
+    async setPowered() {}
+    async stopDiscovery() {}
+}
+
+module.exports = MissingAdapter

--- a/index.js
+++ b/index.js
@@ -687,7 +687,12 @@ module.exports =   function (app) {
 					break
 				}
 			}
-			if (!resolved) throw new Error(`No adapter found with MAC address ${adapterID}`)
+			if (!resolved) {
+				plugin.debug(`No adapter found with MAC address ${adapterID}.`)
+				plugin.setError(`No adapter found with MAC address ${adapterID}.`)
+				await plugin.stop()
+				return
+			}
 			plugin.debug(`Resolved adapter MAC ${adapterID} to ${resolved}`)
 			adapterID = resolved
 		}

--- a/index.js
+++ b/index.js
@@ -672,6 +672,26 @@ module.exports =   function (app) {
 
 		if (!adapterID || adapterID=="")
 			adapterID = "hci0"
+
+		// On Victron devices adapter names are not consistent.
+		// If adapterID looks like a MAC address, resolve it to hciX name
+		if (/^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$/.test(adapterID)) {
+			const wantMac = adapterID.toLowerCase()
+			const adapterNames = await bluetooth.adapters()
+			let resolved = null
+			for (const name of adapterNames) {
+				const a = await bluetooth.getAdapter(name)
+				const mac = await a.getAddress()
+				if (mac.toLowerCase() === wantMac) {
+					resolved = name
+					break
+				}
+			}
+			if (!resolved) throw new Error(`No adapter found with MAC address ${adapterID}`)
+			plugin.debug(`Resolved adapter MAC ${adapterID} to ${resolved}`)
+			adapterID = resolved
+		}
+
 		//Check if Adapter has changed since last start()
 		if (adapter) {
 			if (adapter.adapter!=adapterID) {
@@ -727,8 +747,12 @@ module.exports =   function (app) {
 			plugin.schema.properties.adapter.enum=[]
 			plugin.schema.properties.adapter.enumNames=[]
 			for (a of activeAdapters){
+				const addr = await a.getAddress()
+				const name = await a.getName()
 				plugin.schema.properties.adapter.enum.push(a.adapter)
-				plugin.schema.properties.adapter.enumNames.push(`${a.adapter} @ ${ await a.getAddress()} (${await a.getName()})`)
+				plugin.schema.properties.adapter.enumNames.push(`${a.adapter} @ ${addr} (${name})`)
+				plugin.schema.properties.adapter.enum.push(addr)
+				plugin.schema.properties.adapter.enumNames.push(`${a.adapter} @ ${addr} (${name}) [by MAC]`)
 			}}
 		catch(e){
 			plugin.setError(`Unable to get adapters: ${e.message}`)

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ const {bluetooth, destroy} = createBluetooth()
 const BTSensor = require('./BTSensor.js')
 const BLACKLISTED = require('./sensor_classes/BlackListedDevice.js')
 const OutOfRangeDevice = require("./OutOfRangeDevice.js")
+const MissingAdapter = require("./MissingAdapter.js")
 const { createChannel, createSession } = require("better-sse");
 const { clearTimeout } = require('timers')
 const loadClassMap = require('./classLoader.js')
@@ -673,33 +674,69 @@ module.exports =   function (app) {
 		if (!adapterID || adapterID=="")
 			adapterID = "hci0"
 
+		// Populate adapter dropdown first so the admin UI can show current hardware
+		// even when the configured adapter can't be resolved (missing or unknown hci).
+		try{
+			const activeAdapters = await bluetooth.activeAdapters()
+			if (activeAdapters.length==0){
+				plugin.setError("No active Bluetooth adapters found.")
+			}
+			const adapterInfo = await Promise.all(activeAdapters.map(async (a) => {
+				const [addr, name] = await Promise.all([a.getAddress(), a.getName()])
+				return { hci: a.adapter, addr, name }
+			}))
+			plugin.schema.properties.adapter.enum=[]
+			plugin.schema.properties.adapter.enumNames=[]
+			for (const { hci, addr, name } of adapterInfo) {
+				plugin.schema.properties.adapter.enum.push(hci)
+				plugin.schema.properties.adapter.enumNames.push(`${hci} @ ${addr} (${name})`)
+				plugin.schema.properties.adapter.enum.push(addr)
+				plugin.schema.properties.adapter.enumNames.push(`${hci} @ ${addr} (${name}) [by MAC]`)
+			}
+		}
+		catch(e){
+			plugin.setError(`Unable to get adapters: ${e.message}`)
+		}
+
+		function installMissingAdapter(message){
+			plugin.debug(message)
+			plugin.setError(message)
+			if (adapter)
+				adapter.helper._propsProxy.removeAllListeners()
+			adapter = new MissingAdapter(adapterID)
+		}
+
 		// On Victron devices adapter names are not consistent.
 		// If adapterID looks like a MAC address, resolve it to hciX name
 		if (/^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$/.test(adapterID)) {
 			const wantMac = adapterID.toLowerCase()
-			const adapterNames = await bluetooth.adapters()
 			let resolved = null
-			for (const name of adapterNames) {
-				const a = await bluetooth.getAdapter(name)
-				const mac = await a.getAddress()
-				if (mac.toLowerCase() === wantMac) {
-					resolved = name
-					break
+			try {
+				const adapterNames = await bluetooth.adapters()
+				for (const name of adapterNames) {
+					const a = await bluetooth.getAdapter(name)
+					const mac = await a.getAddress()
+					if (mac.toLowerCase() === wantMac) {
+						resolved = name
+						break
+					}
 				}
+			} catch (e) {
+				installMissingAdapter(`Unable to enumerate adapters while resolving MAC ${adapterID}: ${e.message}`)
+				return
 			}
 			if (!resolved) {
-				plugin.debug(`No adapter found with MAC address ${adapterID}.`)
-				plugin.setError(`No adapter found with MAC address ${adapterID}.`)
-				await plugin.stop()
+				installMissingAdapter(`No adapter found with MAC address ${adapterID}.`)
 				return
 			}
 			plugin.debug(`Resolved adapter MAC ${adapterID} to ${resolved}`)
 			adapterID = resolved
 		}
 
-		//Check if Adapter has changed since last start()
+		//Check if Adapter has changed since last start(), or if the previous
+		//start left a placeholder MissingAdapter that should be re-acquired.
 		if (adapter) {
-			if (adapter.adapter!=adapterID) {
+			if (adapter.adapter!=adapterID || adapter instanceof MissingAdapter) {
 				adapter.helper._propsProxy.removeAllListeners()
 				adapter=null
 			}
@@ -709,7 +746,12 @@ module.exports =   function (app) {
 		if (!adapter){
 			plugin.debug(`Connecting to bluetooth adapter ${adapterID}`);
 
-			adapter = await bluetooth.getAdapter(adapterID)
+			try {
+				adapter = await bluetooth.getAdapter(adapterID)
+			} catch (e) {
+				installMissingAdapter(`Bluetooth Adapter ${adapterID} not found: ${e.message}`)
+				return
+			}
 
 			//Set up DBUS listener to monitor Powered status of current adapter
 
@@ -721,7 +763,7 @@ module.exports =   function (app) {
 							plugin.setStatusText(`Bluetooth Adapter ${adapterID} turned off. Plugin disabled.`)
 							await plugin.stop()
 						}
-					} else { 				
+					} else {
 						await restartPlugin(options)
 					}
 				}
@@ -733,7 +775,7 @@ module.exports =   function (app) {
 				return
 			}
 		}
-	
+
 		sensorMap.clear()
 		if (channel){
 			channel.broadcast({state:"started"},"pluginstate")
@@ -744,25 +786,7 @@ module.exports =   function (app) {
 			plugin.stopped=false
 		}
 
-		try{
-			const activeAdapters = await bluetooth.activeAdapters()
-			if (activeAdapters.length==0){
-				plugin.setError("No active Bluetooth adapters found.")
-			}
-			plugin.schema.properties.adapter.enum=[]
-			plugin.schema.properties.adapter.enumNames=[]
-			for (a of activeAdapters){
-				const addr = await a.getAddress()
-				const name = await a.getName()
-				plugin.schema.properties.adapter.enum.push(a.adapter)
-				plugin.schema.properties.adapter.enumNames.push(`${a.adapter} @ ${addr} (${name})`)
-				plugin.schema.properties.adapter.enum.push(addr)
-				plugin.schema.properties.adapter.enumNames.push(`${a.adapter} @ ${addr} (${name}) [by MAC]`)
-			}}
-		catch(e){
-			plugin.setError(`Unable to get adapters: ${e.message}`)
-		}
-		
+
 		if (starts>0){
 			plugin.debug(`Plugin ${packageInfo.version} restarting...`);
 		} else {


### PR DESCRIPTION
## Summary

On Victron Cerbo GX, the built-in Bluetooth adapter sometimes enumerates as `hci0` and sometimes as `hci1` across reboots, breaking plugin configs that pin the adapter by hci name. This PR lets users pin by MAC address instead, and keeps the plugin's config UI usable when the configured adapter is missing.

Patch contributed by @torbenaa in #133. Iterated per review feedback to use a `MissingAdapter` placeholder rather than calling `plugin.stop()` on failure, so the admin UI can surface the error AND offer the live adapter list at the same time.

## What changed

**`MissingAdapter.js` (new):** stubs the node-ble Adapter surface that `index.js` actually uses (`isPowered`, `isDiscovering`, `devices`, `waitDevice`, `setPowered`, `stopDiscovery`, and the `helper.{_prepare, callMethod, _propsProxy}` DBus internals). All values are empty/no-op so the device-discovery code paths stay inert.

**`index.js`:**
- MAC resolution: if `adapterID` matches a MAC regex, resolve it to the current `hciX` via `bluetooth.adapters()` + `getAdapter(name).getAddress()`.
- Schema dropdown is now populated up front (moved above the adapter-acquisition block) so the live adapter list is always reflected in the admin UI, even on failure paths. Per-adapter `getAddress()` and `getName()` calls now run concurrently via `Promise.all`.
- New `[by MAC]` dropdown entries: each active adapter appears once by hci name (existing) and once by MAC.
- Failure paths use a new `installMissingAdapter(message)` helper that calls `setError`, parks `adapter` as a `MissingAdapter`, and lets `start()` return without `plugin.stop()`:
  - MAC found but no adapter matches.
  - `bluetooth.adapters()` throws while resolving.
  - `bluetooth.getAdapter(adapterID)` throws on an unknown hci (also addresses #122).
- "Adapter already set" check now also forces re-acquire when the prior adapter was a `MissingAdapter`, so a later restart can pick up real hardware that has since appeared.

## Behavior

| Configured adapter | Powered? | Behavior |
|---|---|---|
| Valid `hciX` | yes | unchanged: connects and scans |
| Valid MAC | yes | resolves MAC then connects |
| MAC matches no adapter | n/a | `setError`, plugin stays started with `MissingAdapter`, dropdown shows current hardware |
| Unknown `hciX` | n/a | `setError`, plugin stays started with `MissingAdapter`, dropdown shows current hardware (closes #122) |
| Valid hciX or MAC | no | unchanged: `setError` + `plugin.stop()` |

The powered-off branch is intentionally untouched: the request was scoped to adapter resolution, not power state.

## Test plan

I have no Cerbo, so this is the verification I'd ask for on real hardware:

- [ ] **Regression**: existing `hci0` / `hci1` selection still works.
- [ ] **MAC happy path**: in the admin UI, pick the new `[by MAC]` dropdown entry; confirm plugin starts and connects to BLE devices as before.
- [ ] **Cerbo GX hci flip**: configure by MAC, reboot until the adapter reorders to a different `hciX`; confirm plugin still connects (original bug from #133).
- [ ] **Bad MAC**: hand-edit config to a MAC that doesn't match any adapter (e.g. `00:00:00:00:00:00`); confirm:
  - error `No adapter found with MAC address ...` appears in the admin UI,
  - the plugin stays running (no admin-UI "stopped" badge),
  - the adapter dropdown reflects current hardware,
  - picking a valid entry and saving brings the plugin back without restarting SignalK.
- [ ] **Unknown hciX**: edit config to `hci99`; confirm same behavior as bad MAC (this is #122 today, where `getAdapter()` throws an unhandled rejection).
- [ ] **Powered-off**: turn the BT adapter off and reload; confirm the existing `Bluetooth Adapter X not powered on` error fires and plugin stops (no behavior change).
- [ ] **Plug-in after-the-fact**: configure a MAC for an adapter that isn't connected yet, start with `MissingAdapter` in place, then connect the adapter and reload; confirm the real adapter is acquired and devices are discovered.

## Notes

- MAC regex is intentionally inline; used once, named constant didn't add clarity.
- `bluetooth.getAdapter("hciX")` throwing on unknown hci names is the root cause of #122; the new try/catch turns it into a clean error.

Closes #122. Closes #133.

Generated with [Claude Code](https://claude.com/claude-code)