### PR TITLE
fix: clear poll interval on GATT disconnect in four BMS classes

### DIFF
--- a/sensor_classes/HumsienkBMS.js
+++ b/sensor_classes/HumsienkBMS.js
@@ -390,6 +390,10 @@ class HumsienkBMS extends BTSensor {
   }
 
   async deactivateGATT() {
+    if (this.intervalID) {
+      clearInterval(this.intervalID);
+      this.intervalID = null;
+    }
     await this.stopGATTNotifications(this.rxChar);
     await super.deactivateGATT();
   }

--- a/sensor_classes/JikongBMS.js
+++ b/sensor_classes/JikongBMS.js
@@ -532,7 +532,11 @@ class JikongBMS extends BTSensor {
   }
 
   async deactivateGATT() {
-    await this.stopGATTNotifications(this.rxChar) 
+    if (this.intervalID) {
+      clearInterval(this.intervalID);
+      this.intervalID = null;
+    }
+    await this.stopGATTNotifications(this.rxChar)
 
     await super.deactivateGATT();
   }

--- a/sensor_classes/Renogy/RenogySensor.js
+++ b/sensor_classes/Renogy/RenogySensor.js
@@ -118,6 +118,10 @@ class RenogySensor extends BTSensor{
         return true
     }
     async deactivateGATT(){
+        if (this.intervalID) {
+            clearInterval(this.intervalID)
+            this.intervalID = null
+        }
         await this.stopGATTNotifications(this.readChar)
         await super.deactivateGATT()
     }

--- a/sensor_classes/ShenzhenLiOnBMS.js
+++ b/sensor_classes/ShenzhenLiOnBMS.js
@@ -193,8 +193,12 @@ class ShenzhenLiONBMS extends BTSensor{
     }
   
     async deactivateGATT(){
+        if (this.intervalID) {
+            clearInterval(this.intervalID)
+            this.intervalID = null
+        }
         await this.stopGATTNotifications(this.rxCharacteristic)
-        await super.deactivateGATT() 
+        await super.deactivateGATT()
     }
 }
 module.exports=ShenzhenLiONBMS


### PR DESCRIPTION
## Summary

Four GATT-polling BMS classes set `this.intervalID = setInterval(...)` in their init paths but never `clearInterval` in `deactivateGATT()`. On the auto-reconnect path the interval is orphaned, and a fresh one is created, so poll cadence doubles every disconnect/reconnect cycle.

This extends the lifecycle theme of #144. Same shape as `JBDBMS.deactivateGATT` (line 405) and `WattCycleBMS.deactivateGATT` (line 349), which already do it right.

## Affected classes

| File | setInterval | Cleared in deactivateGATT before this PR? |
|---|---|---|
| `JBDBMS.js:382` | yes | yes (`:405-407`) |
| `WattCycleBMS.js:325` | yes | yes (`:349-352`) |
| `HumsienkBMS.js:214` | yes | **no** |
| `JikongBMS.js:578` | yes | **no** |
| `Renogy/RenogySensor.js:89` | yes | **no** |
| `ShenzhenLiOnBMS.js:188` | yes | **no** |

`Renogy/RenogySensor.js` is the parent of `RenogyBattery`, `RenogyInverter`, and `RenogyRoverClient`, so the one fix covers all three concrete Renogy classes.

## What changed

Each of the four `deactivateGATT()` bodies gains the same guard:

```js
if (this.intervalID) {
    clearInterval(this.intervalID)
    this.intervalID = null
}
```

Indentation/quoting/semis follow each file's existing style (4-space tabs no semis for Renogy/Shenzhen, 2-space + semis for Humsienk/Jikong).

## Why the leak hid

`BTSensor.stopListening()` (`BTSensor.js:1079`) clears `this.intervalID` before calling `deactivateGATT()`, so the full plugin-stop path was always clean. Only the auto-reconnect path at `BTSensor.js:654` invokes `deactivateGATT()` directly without first clearing the interval, which is why the leak only manifests on the wire-disconnect path that users probably hit most often (BLE adapter glitch, device sleep, range loss).

## Test plan

The maintainer is the one with the hardware. Suggested checks per affected device:

- [ ] **Cold start**: confirm `${getName()}::initGATTInterval pollFreq=...` debug line is logged once and one query fires per `pollFreq` window.
- [ ] **Forced disconnect/reconnect**: power-cycle the BLE adapter (or move the sensor out of range and back). Confirm in debug logs that the per-pollFreq query rate stays at 1x rather than doubling. Repeat 2-3 cycles to be sure (the bug compounds: cycle N sees N timers firing).
- [ ] **Full plugin stop**: `enable=false` then `enable=true` from admin UI; confirm no orphan timers (this path was already correct, included as regression check).
- [ ] **Memory**: under sustained reconnect loops on a real device, RSS shouldn't climb. Hardest to observe but the underlying mechanism is clear from the code.

## Out of scope (related findings, queued for later)

While verifying the leak, two unrelated bugs surfaced in adjacent files:

- `ShenzhenLiOnBMS.js:134` decodes the protection-state bitfield (e.g. `0x4 | 0x40 = 0x44`) as a single-key lookup, so any combination of simultaneous protections silently falls to `"Normal"`. Want this as a separate `fix:` PR?
- `RenogyBattery.js:104,116` has a backwards `for` loop (`for (let i=0; i++ ; i < this.numberOfCells)`) so per-cell voltages and temperatures are never emitted at all. Plus the cell-temperature decoder shares the cell-voltage offset and lacks scaling, so even fixing the loop alone would emit wrong values. Wants protocol verification on real hardware before I touch it.

Closes nothing yet, but if you'd like me to track these, I'll open issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)