### PR TITLE
fix: report all active protection alarms in ShenzhenLiOnBMS

### DIFF
--- a/sensor_classes/ShenzhenLiOnBMS.js
+++ b/sensor_classes/ShenzhenLiOnBMS.js
@@ -131,7 +131,13 @@ class ShenzhenLiONBMS extends BTSensor{
             .default="electrical.batteries.{batteryID}.balanceMemoryActive"
 
         this.addMetadatum('protectionState','', 'protection state',
-                (buff)=>{return ProtectionStatus[buff.readUInt16LE(76)]??"Normal"})
+                (buff)=>{
+                    const bits = buff.readUInt16LE(76)
+                    const states = new Set()
+                    for (const [mask, label] of Object.entries(ProtectionStatus))
+                        if (bits & Number(mask)) states.add(label)
+                    return states.size === 0 ? "Normal" : [...states].join(", ")
+                })
             .default="electrical.batteries.{batteryID}.protectionState"
 
         this.addMetadatum('failureState','', 'failure state',


### PR DESCRIPTION
## Summary

The protection-state decoder in `ShenzhenLiOnBMS.js` treats a bitfield as an enum, so any combination of simultaneous protections silently falls through to `"Normal"`. On a battery monitor that means active alarms can fire and the SignalK delta still claims everything is fine.

## The bug

`sensor_classes/ShenzhenLiOnBMS.js:134`:

```js
this.addMetadatum('protectionState','', 'protection state',
        (buff)=>{return ProtectionStatus[buff.readUInt16LE(76)]??"Normal"})
```

The `ProtectionStatus` lookup table only has entries for single-bit values (`0x4`, `0x20`, `0x40`, `0x80`, `0x100`, `0x200`, `0x400`, `0x800`, `0x4000`). Any multi-bit combination, e.g. cell over-voltage `0x4` + charging over-current `0x40` = `0x44`, misses the table and the `??` falls through to `"Normal"`.

The in-file comment block at lines 83-92 explicitly documents this field as a bitfield:

> `00000004 = Over Charge Protection, 00000020 = Over-discharge Protection, 00000040 = Charging Over Current Protection, 00000080 = Discharging Over Current Protection, 00000100 = High-temp Protection, ...`

So the protocol contract is "non-zero means at least one protection is firing", and bits can co-occur. The decoder ignored that.

## The fix

Iterate the bits, collect matching labels into a `Set`, comma-join. The `Set` handles the dedup case where both `0x100` and `0x200` map to `"High-temp Protection"` (and same for `0x400`/`0x800`).

```js
(buff)=>{
    const bits = buff.readUInt16LE(76)
    const states = new Set()
    for (const [mask, label] of Object.entries(ProtectionStatus))
        if (bits & Number(mask)) states.add(label)
    return states.size === 0 ? "Normal" : [...states].join(", ")
}
```

Path and value type are unchanged: still emits a string at `electrical.batteries.{batteryID}.protectionState`. Existing dashboards that key on the literal `"Normal"` still work.

## Test cases (verified locally with a node one-liner against the table)

| Input bits | Old output | New output |
|---|---|---|
| `0x0000` | `Normal` | `Normal` |
| `0x0004` (over-charge alone) | `Over Charge Protection` | `Over Charge Protection` |
| `0x0044` (over-charge + over-current) | **`Normal`** (BUG) | `Over Charge Protection, Charging Over Current Protection` |
| `0x0300` (both high-temp bits) | `Normal` (BUG) | `High-temp Protection` (deduped) |
| `0x0c00` (both low-temp bits) | `Normal` (BUG) | `Low-temp Protection` (deduped) |
| `0x4040` (short-circuit + over-current) | `Normal` (BUG) | `Charging Over Current Protection, Short Circuit Protection` |
| `0x0001` (unknown bit only) | `Normal` | `Normal` |
| `0x0005` (over-charge + unknown bit) | `Normal` (BUG) | `Over Charge Protection` |

## Test plan

- [ ] Hardware: trigger a single protection (e.g. over-current); confirm the delta string matches the corresponding table entry exactly (regression check that single-bit cases still emit the same value).
- [ ] Hardware: trigger two protections simultaneously (e.g. cell over-voltage AND charging over-current; achievable by stress-charging at the cell-balance limit); confirm the delta now reports both labels comma-joined instead of `"Normal"`.
- [ ] Idle: confirm `"Normal"` still emits when no protections are firing.

## Out of scope

The protocol comment at `:84` describes the protection field as 4 bytes (`t.slice(76, 80)`), but the decoder only reads the low 16 bits via `readUInt16LE(76)`. All current `ProtectionStatus` table entries fit in the low 16 bits (max is `0x4000`), so no information is lost today. If new protection bits appear in the high 16 bits, switching to `readUInt32LE(76)` would be needed; deferring until/unless that comes up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)