### PR TITLE
fix: correct operator precedence in elapsedTimeSinceLastContact

### DIFF
--- a/BTSensor.js
+++ b/BTSensor.js
@@ -1136,8 +1136,7 @@ class BTSensor extends EventEmitter {
     elapsedTimeSinceLastContact(){
         if (this.device instanceof OutOfRangeDevice)
             return Infinity
-        else 
-            return (Date.now()-this?._lastContact??Date.now())/1000
+        return (Date.now() - (this._lastContact ?? Date.now())) / 1000
     }
 
     prepareConfig(config){


### PR DESCRIPTION
## Summary
- `(Date.now()-this?._lastContact??Date.now())/1000` parses as `(Date.now() - this._lastContact) ?? Date.now()` divided by 1000. When `_lastContact` is undefined that's `NaN ?? Date.now()` = `NaN` (`??` only matches null/undefined, not NaN), so the function returns `NaN/1000` = `NaN`, not the apparent intended fallback of `0`.
- The parentheses restore what the `??` was clearly trying to do: fall back to `Date.now()` when `_lastContact` is unset, so elapsed reads 0 before any contact has been recorded.
- Today `_lastContact` is stamped synthetically during `activate()`, so this path is currently unreachable. The bug becomes load-bearing as soon as the synthetic stamp is removed (companion PR).

## Test plan
- [ ] Plugin starts and runs normally.
- [ ] `sensor.elapsedTimeSinceLastContact()` returns 0 for a sensor whose `_lastContact` has not yet been stamped, instead of `NaN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)