### PR TITLE
fix: default DuplicateData to true so adapter reports every advertisement

### DIFF
--- a/index.js
+++ b/index.js
@@ -174,7 +174,7 @@ module.exports =   function (app) {
 				type: "string", default: "hci0"},
 			transport: {title: "Transport ",
 				type: "string", enum: ["auto","le","bredr"], default: "le", enumNames:["Auto", "LE-Bluetooth Low Energy", "BR/EDR Bluetooth basic rate/enhanced data rate"]},
-			duplicateData: {title: "Set scanner to report duplicate data", type: "boolean", default: false, },
+			duplicateData: {title: "Set scanner to report duplicate data", type: "boolean", default: true, },
 			discoveryTimeout: {title: "Default device discovery timeout (in seconds)", 
 				type: "integer", default: 30,
 				minimum: 10,
@@ -411,7 +411,7 @@ module.exports =   function (app) {
 		async function startScanner(options) {
 		
 			const transport = options?.transport??"le"
-			const duplicateData = options?.duplicateData??false
+			const duplicateData = options?.duplicateData??true
 			plugin.debug("Starting scan...");
 			//Use adapter.helper directly to get around Adapter::startDiscovery()
 			//filter options which can cause issues with Device::Connect() 


### PR DESCRIPTION
## Summary
- BlueZ's `SetDiscoveryFilter` accepts `DuplicateData` (boolean). `true` disables duplicate detection so `PropertiesChanged` fires for every received advertisement; `false` enables filtering so `PropertiesChanged` only fires when the payload bytes change. BlueZ's own default is `true`.
- The plugin currently overrides to `false`, which suppresses `PropertiesChanged` for stable-payload devices (battery monitors, environmental sensors with slow-moving averages). `_lastContact` then stops updating between payload changes even though the device is still advertising normally, and liveness tracking degrades to false `No contact` warnings.
- Both the schema default and the `startScanner` runtime fallback flip to `true`. Users who want filtering can still set `duplicateData: false` explicitly.

## Test plan
- [ ] Fresh install (no existing plugin config), start the plugin, confirm `Setting Bluetooth transport option to le. DuplicateData to true` in the debug log.
- [ ] Pick a sensor whose advertised payload is stable for tens of seconds (e.g. a resting battery monitor). Confirm `_lastContact` advances at the advertising interval, not only when the payload bytes change.
- [ ] Existing users with `duplicateData: false` in their saved config: confirm the saved setting still wins over the new default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)