### PR TITLE
fix: decode JBDBMS protectionStatus with bitmasks instead of string indexing

### DIFF
--- a/sensor_classes/JBDBMS.js
+++ b/sensor_classes/JBDBMS.js
@@ -96,21 +96,21 @@ class JBDBMS extends BTSensor {
     };
 
     this.addMetadatum("protectionStatus", "", "Protection Status", (buffer) => {
-      const bits = buffer.readUInt16BE(20).toString(2);
+      const word = buffer.readUInt16BE(20);
       return {
-        singleCellOvervolt: bits[0] == "1",
-        singleCellUndervolt: bits[1] == "1",
-        packOvervolt: bits[2] == "1",
-        packUndervolt: bits[3] == "1",
-        chargeOvertemp: bits[4] == "1",
-        chargeUndertemp: bits[5] == "1",
-        dischargeOvertemp: bits[6] == "1",
-        dischargeUndertemp: bits[7] == "1",
-        chargeOvercurrent: bits[8] == "1",
-        dischargeOvercurrent: bits[9] == "1",
-        shortCircut: bits[10] == "1",
-        frontEndDetectionICError: bits[11] == "1",
-        softwareLockMOS: bits[12] == "1",
+        singleCellOvervolt:       (word & 0x0001) !== 0,
+        singleCellUndervolt:      (word & 0x0002) !== 0,
+        packOvervolt:             (word & 0x0004) !== 0,
+        packUndervolt:            (word & 0x0008) !== 0,
+        chargeOvertemp:           (word & 0x0010) !== 0,
+        chargeUndertemp:          (word & 0x0020) !== 0,
+        dischargeOvertemp:        (word & 0x0040) !== 0,
+        dischargeUndertemp:       (word & 0x0080) !== 0,
+        chargeOvercurrent:        (word & 0x0100) !== 0,
+        dischargeOvercurrent:     (word & 0x0200) !== 0,
+        shortCircut:              (word & 0x0400) !== 0,
+        frontEndDetectionICError: (word & 0x0800) !== 0,
+        softwareLockMOS:          (word & 0x1000) !== 0,
       };
     }).default = "electrical.batteries.{batteryID}.protectionStatus";
 


### PR DESCRIPTION
## Summary

`JBDBMS.protectionStatus` decoder uses `word.toString(2)` then indexes by character position, which reads the wrong bit for every non-zero word. Result: `singleCellOvervolt` is reported `true` whenever ANY protection bit is set, and the other named flags are mostly silenced.

## The bug

`sensor_classes/JBDBMS.js:99`:

```js
const bits = buffer.readUInt16BE(20).toString(2);
return {
    singleCellOvervolt: bits[0] == "1",
    singleCellUndervolt: bits[1] == "1",
    ...
};
```

`Number.toString(2)` returns a binary string with **no leading zeros**. So `bits[0]` is the most significant `1` bit of the value, not bit 0 of the protocol. Examples:

| `word` | `bits` from `toString(2)` | Old `singleCellOvervolt` (`bits[0] == "1"`) | Actually active per spec |
|---|---|---|---|
| `0x0001` | `"1"` | `true` ✓ | `singleCellOvervolt` |
| `0x0002` | `"10"` | `true` ❌ | `singleCellUndervolt` |
| `0x0040` | `"1000000"` | `true` ❌ | `dischargeOvertemp` |
| `0x0400` | `"10000000000"` | `true` ❌ | `shortCircut` |
| `0x8000` | `"1000000000000000"` | `true` (coincidence) | (unmapped high bit) |

For any non-zero word, `singleCellOvervolt` is reported `true`. Most of the other named flags are never reachable because `bits` is shorter than `13` characters for typical low-bit protections, so `bits[12]` is `undefined` and `softwareLockMOS` reads `false`.

## The fix

Use explicit bitwise masks per the JBD protocol field assignments:

```js
const word = buffer.readUInt16BE(20);
return {
    singleCellOvervolt:       (word & 0x0001) !== 0,
    singleCellUndervolt:      (word & 0x0002) !== 0,
    packOvervolt:             (word & 0x0004) !== 0,
    packUndervolt:            (word & 0x0008) !== 0,
    chargeOvertemp:           (word & 0x0010) !== 0,
    chargeUndertemp:          (word & 0x0020) !== 0,
    dischargeOvertemp:        (word & 0x0040) !== 0,
    dischargeUndertemp:       (word & 0x0080) !== 0,
    chargeOvercurrent:        (word & 0x0100) !== 0,
    dischargeOvercurrent:     (word & 0x0200) !== 0,
    shortCircut:              (word & 0x0400) !== 0,
    frontEndDetectionICError: (word & 0x0800) !== 0,
    softwareLockMOS:          (word & 0x1000) !== 0,
};
```

Same field names, same value shape, same path. Just correctness.

## Test plan

- [ ] Hardware: trigger a known single protection (e.g. let the bank charge above the over-voltage threshold). Confirm only the corresponding `protectionStatus.<name>` is `true`, others are `false`. Before this PR, `singleCellOvervolt` would have been `true` regardless of which protection was actually firing.
- [ ] Idle: confirm all flags read `false` when no protections are firing.
- [ ] Multi-bit: if hardware allows two simultaneous protections (e.g. low temp + over-current), confirm both report `true`.

## Out of scope

- The typo `shortCircut` (missing 'i') is preserved to avoid breaking any dashboard or downstream consumer that keys on the existing field name. Worth a separate, opt-in alias rename if anyone cares.
- The decoder reads 16 bits via `readUInt16BE(20)`. All currently mapped bits fit in the low 13. If the JBD protocol adds bits in the high range, switch to `readUInt32BE`.

Generated with [Claude Code](https://claude.com/claude-code)
