### PR TITLE
feat: derive timeRemaining for JBD BMS batteries

### DIFF
--- a/sensor_classes/JBDBMS.js
+++ b/sensor_classes/JBDBMS.js
@@ -89,6 +89,18 @@ class JBDBMS extends BTSensor {
       }
     ).default = "electrical.batteries.capacity.actual";
 
+    // JBD has no native time-to-go field; derive it from remaining charge
+    // and discharge current. Only meaningful while discharging.
+    this.addDefaultPath(
+      "timeRemaining",
+      "electrical.batteries.capacity.timeRemaining"
+    ).read = (buffer) => {
+      const current = buffer.readInt16BE(6) / 100;      // A, -ve = discharging
+      const remainingAh = buffer.readUInt16BE(8) / 100; // Ah
+      if (current >= 0) return null;
+      return (remainingAh / -current) * 3600;           // s
+    };
+
     this.addDefaultPath("cycles", "electrical.batteries.cycles").read = (
       buffer
     ) => {
@@ -342,6 +354,7 @@ class JBDBMS extends BTSensor {
         "voltage",
         "remainingCapacity",
         "capacity",
+        "timeRemaining",
         "cycles",
         "protectionStatus",
         "SOC",


### PR DESCRIPTION
## Summary

JBD BMS units broadcast no native time-to-go field, so `electrical.batteries.capacity.timeRemaining` was never populated for JBD batteries (the path simply did not exist on them). This adds a computed `timeRemaining` path to `JBDBMS`.

- Derives time-to-go as remaining charge (Ah) divided by discharge current, expressed in seconds.
- Returns `null` while charging or idle (`current >= 0`), since time-to-go is only meaningful under a discharge load. `null` matches the Signal K convention for an unavailable value and is consistent with what NMEA 2000 sources publish on the same path.
- Reuses the existing `0x03` basic-info buffer already fetched in `getAndEmitBatteryInfo()`, so it adds no extra BLE traffic.

The path uses the predefined `electrical.batteries.{batteryID}.capacity.timeRemaining` definition from `plugin_defaults.json`, the same one `VictronBatteryMonitor`, `VictronLynxSmartBMS`, and `Junctek` use.

## Test plan

- [x] Verified the computation against synthetic JBD basic-info buffers: 50 Ah at -1.5 A discharge yields 120000 s; idle (0 A) and charging (+ve current) yield `null`.
- [x] Hardware-tested on three live JBD batteries: discharging units reported correct values (e.g. 105 Ah at -2.2 A produced 171802 s, cross-checked exactly), and idle units correctly reported `null`.