### PR TITLE
fix: restore GATT contact heartbeat broken by emit() rename

### DIFF
--- a/BTSensor.js
+++ b/BTSensor.js
@@ -1008,9 +1008,9 @@ class BTSensor extends EventEmitter {
         this._currentValues[tag]=value
     }
 
-    _emit(tag, value){
+    emit(tag, value){
         super.emit(tag, value)
-        if (this.usingGATT()) //update last contact time only for GATT devices 
+        if (this.usingGATT()) //update last contact time only for GATT devices
                               //which do not receive propertyChanged events when connected
             this._lastContact=Date.now()
         this.setCurrentValue(tag,value)

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
   },
   "scripts": {
     "format": "prettier-standard 'index.js'",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --test",
     "prepublishOnly": "npm run clean && npm run build",
     "dev": "webpack --watch --mode development",
     "build": "webpack --mode=production",

--- a/spec/contact_tracking.test.js
+++ b/spec/contact_tracking.test.js
@@ -1,0 +1,46 @@
+/**
+ * Tests for GATT contact tracking.
+ * Run with: node --test spec/contact_tracking.test.js
+ *
+ * A GATT-polled sensor (e.g. a BMS) does not receive BlueZ PropertiesChanged
+ * signals while connected, so its only contact heartbeat is the value-emit
+ * path. emit(tag, value) must stamp _lastContact for GATT sensors, otherwise
+ * _lastContact freezes at connect time and the health check raises a
+ * "No contact" warning that never clears even while data is flowing.
+ */
+
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const BTSensor = require("../BTSensor");
+
+test("emit() stamps _lastContact for a GATT sensor", () => {
+  const sensor = new BTSensor(null, { useGATT: true });
+
+  assert.equal(sensor._lastContact, undefined);
+
+  const before = Date.now();
+  sensor.emit("voltage", 12.5);
+
+  assert.equal(typeof sensor._lastContact, "number");
+  assert.ok(sensor._lastContact >= before);
+});
+
+test("emit() caches the value for getCurrentValue()", () => {
+  const sensor = new BTSensor(null, { useGATT: true });
+
+  sensor.emit("voltage", 12.5);
+
+  assert.equal(sensor.getCurrentValue("voltage"), 12.5);
+});
+
+test("emit() does not stamp _lastContact for a non-GATT sensor", () => {
+  const sensor = new BTSensor(null, { useGATT: false });
+
+  sensor.emit("voltage", 12.5);
+
+  // Advertisement sensors are stamped by _propertiesChanged, not emit().
+  assert.equal(sensor._lastContact, undefined);
+});


### PR DESCRIPTION
## Summary

`BTSensor#emit(tag, value)` is an override of `EventEmitter.prototype.emit`.
For GATT-polled sensors it is the only contact heartbeat: those sensors
do not receive BlueZ `PropertiesChanged` signals while connected, so `emit()`
stamps `_lastContact` on every value emitted.

Commit 2eb44b5 ("Rate limiting feature added") renamed this override to
`_emit` but left the ~100 `this.emit(...)` call sites untouched. The override
became dead code: `this.emit(...)` reverted to the native `EventEmitter`
emit, so for GATT sensors `_lastContact` stopped advancing and
`setCurrentValue` stopped being called.

Symptom: a connected BMS keeps publishing battery data every few seconds,
but `_lastContact` stays frozen at connect time. `elapsedTimeSinceLastContact()`
grows without bound and the device-health check raises a
`notifications.sensors.<mac>` "No contact" warning that never clears, even
though data is flowing.

## Changes

- `BTSensor.js`: rename `_emit` back to `emit`, restoring the override that
  held from 2024 until Feb 2026.
- `spec/contact_tracking.test.js`: regression test covering the GATT
  heartbeat, value caching, and the non-GATT case.
- `package.json`: point the `test` script at `node --test`; it was a
  "no test specified" stub, so the new test could not run under `npm test`.

## Test plan

- [x] `npm test` passes (27 tests: 3 new + 24 existing).
- [x] Reverting the one-line fix makes 2 of the 3 new tests fail.
- [ ] Hardware: with a GATT sensor (e.g. JBD BMS) configured and
  reporting, confirm no `notifications.sensors.<mac>` "No contact" warning
  appears after `noContactThreshold` seconds while data is flowing.
- [ ] Hardware: take a GATT sensor out of range, confirm the warning is
  raised, bring it back, confirm it clears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)