### PR TITLE
Victron robustness, Adapter retry, Path clearing

### DIFF
--- a/BTSensor.js
+++ b/BTSensor.js
@@ -1291,7 +1291,10 @@ class BTSensor extends EventEmitter {
   }
    clearNoContact(){
 	    this.setReachable(true)
-    	this._app.handleMessage('bt-sensors-plugin-sk', 
+        const rssi = this.getRSSI()
+        if (Number.isFinite(rssi))
+            this.emit("RSSI", rssi)
+    	this._app.handleMessage('bt-sensors-plugin-sk',
             {
                 updates: [{
                     $source: this.getName(),

--- a/BTSensor.js
+++ b/BTSensor.js
@@ -866,10 +866,14 @@ class BTSensor extends EventEmitter {
         return name?name:"Unknown"
 
     }
+    sanitizePathKey(str) {
+        return str.replace(/[^a-zA-Z0-9_-]/g, '_').replace(/_+/g, '_').replace(/^_|_$/g, '')
+    }
+
     macAndName(){
         if (this.getMacAddress()==null)
             this.debug(`macAndName called with null MAC address for ${this.getName()}`)
-        const name = this.getName().replace(/[^a-zA-Z0-9]/g,'_').replace(/_+/g,'_').replace(/^_|_$/g,'')
+        const name = this.sanitizePathKey(this.getName())
         const mac = this.getMacAddress().replaceAll(':', '_')
         return `${name}_${mac}`
     }
@@ -1219,7 +1223,7 @@ class BTSensor extends EventEmitter {
                 evalResult= evalResult.call(this)
             }
 
-            resultString += evalResult !== undefined ? evalResult.replace(/[^a-zA-Z0-9_]/g,'_').replace(/_+/g,'_').replace(/^_|_$/g,'') : `${keyToAccess}_value_undefined`;
+            resultString += evalResult !== undefined ? this.sanitizePathKey(evalResult) : `${keyToAccess}_value_undefined`;
         } catch (error) {
             console.error(`Error accessing key '${keyToAccess}':`, error);
             resultString += fullMatch; // Keep the original curly braces on error

--- a/BTSensor.js
+++ b/BTSensor.js
@@ -1223,7 +1223,7 @@ class BTSensor extends EventEmitter {
                 evalResult= evalResult.call(this)
             }
 
-            resultString += evalResult !== undefined ? this.sanitizePathKey(evalResult) : `${keyToAccess}_value_undefined`;
+            resultString += evalResult !== undefined ? evalResult.replace(/\s+/g,'_') : `${keyToAccess}_value_undefined`;
         } catch (error) {
             console.error(`Error accessing key '${keyToAccess}':`, error);
             resultString += fullMatch; // Keep the original curly braces on error

--- a/BTSensor.js
+++ b/BTSensor.js
@@ -1024,6 +1024,11 @@ class BTSensor extends EventEmitter {
      */
      setReachable(reachable){
          this._reachable=reachable
+         if (!reachable && this._registeredPaths) {
+             this._registeredPaths.forEach(({path, id, source}) =>
+                 this.updatePath(path, null, id, source)
+             )
+         }
          this.emit("reachable", reachable)
 	 }
     
@@ -1161,11 +1166,14 @@ class BTSensor extends EventEmitter {
 
 	 initPaths(deviceConfig, id){
         const source = this.getName()
+        this._registeredPaths = []
 		Object.keys(this.getPaths()).forEach((tag)=>{
             const pathMeta=this.getPath(tag)
 			const path = deviceConfig.paths[tag];
 			if (!(path === undefined)) {
                 let preparedPath =  this.preparePath(path)
+                if (tag !== "reachable")
+                    this._registeredPaths.push({ path: preparedPath, id, source })
                 this.on(tag, (val)=>{
 					this.updatePath(preparedPath,val, id, source)
                 })

--- a/BTSensor.js
+++ b/BTSensor.js
@@ -1024,13 +1024,15 @@ class BTSensor extends EventEmitter {
      */
      setReachable(reachable){
          this._reachable=reachable
-         if (!reachable && this._registeredPaths) {
+         this.emit("reachable", reachable)
+	 }
+
+     clearAllPaths(){
+         if (this._registeredPaths)
              this._registeredPaths.forEach(({path, id, source}) =>
                  this.updatePath(path, null, id, source)
              )
-         }
-         this.emit("reachable", reachable)
-	 }
+     }
     
     propertiesChanged(props){
         //implemented by subclass
@@ -1231,7 +1233,8 @@ class BTSensor extends EventEmitter {
   }
 
   notifyUnableToCommunicate(){
-    	this._app.handleMessage('bt-sensors-plugin-sk', 
+        this.clearAllPaths()
+    	this._app.handleMessage('bt-sensors-plugin-sk',
             {
                 updates: [{
                     $source: this.getName(),
@@ -1267,7 +1270,8 @@ class BTSensor extends EventEmitter {
   }
  notifyNoContact(){
 	 	this.setReachable(false)
-    	this._app.handleMessage('bt-sensors-plugin-sk', 
+        this.clearAllPaths()
+    	this._app.handleMessage('bt-sensors-plugin-sk',
             {
                 updates: [{
                     $source: this.getName(),

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@
 - Clear all registered paths when a device becomes unreachable or out of contact.
 - Re-emit RSSI on reconnect and fix sensor-list ordering so RSSI updates flow.
 - Retry Bluetooth adapter acquisition instead of failing immediately.
-- Allow dashes in SK path names
+- Revert previous path name rewrite
+- Sanitize macAndName value only
 
 # Version 1.3.8.beta8
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 - Clear all registered paths when a device becomes unreachable or out of contact.
 - Re-emit RSSI on reconnect and fix sensor-list ordering so RSSI updates flow.
 - Retry Bluetooth adapter acquisition instead of failing immediately.
+- Allow dashes in SK path names
 
 # Version 1.3.8.beta8
 

--- a/README.md
+++ b/README.md
@@ -2,9 +2,15 @@
 
 ## WHAT'S NEW  
 
+# Version 1.3.8.beta9
+- Discard invalid/garbage Victron advertisements (device-state 0xFF, key mismatch, duplicate IV).
+- Return null for Operation Mode / Charger Error when the code is 0xFF.
+- Clear all registered paths when a device becomes unreachable or out of contact.
+- Re-emit RSSI on reconnect and fix sensor-list ordering so RSSI updates flow.
+- Retry Bluetooth adapter acquisition instead of failing immediately.
+
 # Version 1.3.8.beta8
 
-- Add GitHub Actions workflow for NodeJS with Webpack
 - Create valid Signal K path names
 - Improve `emitAlarm` handling so null-clear is only sent after a prior alarm was emitted during the session
 - Fix reachable handling and add `reachable` path/property support

--- a/index.js
+++ b/index.js
@@ -746,11 +746,23 @@ module.exports =   function (app) {
 		if (!adapter){
 			plugin.debug(`Connecting to bluetooth adapter ${adapterID}`);
 
-			try {
-				adapter = await bluetooth.getAdapter(adapterID)
-			} catch (e) {
-				installMissingAdapter(`Bluetooth Adapter ${adapterID} not found: ${e.message}`)
-				return
+			const maxAttempts = 5
+			const retryDelay = 3000
+			for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+				try {
+					adapter = await bluetooth.getAdapter(adapterID)
+					break
+				} catch (e) {
+					if (attempt < maxAttempts) {
+						const msg = `Bluetooth adapter ${adapterID} not ready (attempt ${attempt}/${maxAttempts}), retrying in ${retryDelay/1000}s...`
+						plugin.debug(msg)
+						plugin.setStatusText(msg)
+						await new Promise(resolve => setTimeout(resolve, retryDelay))
+					} else {
+						installMissingAdapter(`Bluetooth Adapter ${adapterID} not found: ${e.message}`)
+						return
+					}
+				}
 			}
 
 			//Set up DBUS listener to monitor Powered status of current adapter

--- a/index.js
+++ b/index.js
@@ -510,6 +510,8 @@ module.exports =   function (app) {
 					device.once("deviceFound",async (device)=>{
 						s.device=device
 						s.listen()
+						removeSensorFromList(s)
+						addSensorToList(s)
 						if (config.active) {
 							s.clearUnableToCommunicate()
 							await s.activate(config, plugin)
@@ -518,8 +520,6 @@ module.exports =   function (app) {
 							s.unsetError()
 							s.setState("DORMANT")
 						}
-						removeSensorFromList(s)
-						addSensorToList(s)
 					})
 					addSensorToList(s)
 					resolve(s)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bt-sensors-plugin-sk",
-  "version": "1.3.8-beta8",
+  "version": "1.3.8-beta9",
   "description": "Bluetooth Sensors for Signalk - see https://www.npmjs.com/package/bt-sensors-plugin-sk#supported-sensors for a list of supported sensors",
   "main": "index.js",
   "dependencies": {

--- a/sensor_classes/Victron/VictronSensor.js
+++ b/sensor_classes/Victron/VictronSensor.js
@@ -171,28 +171,35 @@ const VictronIdentifier = require('./VictronIdentifier.js');
     getName(){
         return `Victron ${this.getModelName()}`
     }
+    // Byte 0 of the decrypted payload is device_state for all advertising device types.
+    // 0xFF means "unavailable / powering off" per the Victron spec and should be discarded.
+    // VictronBatteryMonitor overrides this because its byte 0 is the TTG low byte, not state.
+    isDecryptedValid(decData){
+        return decData.length > 0 && decData[0] !== 0xFF
+    }
+
     propertiesChanged(props){
         super.propertiesChanged(props)
         if (this.usingGATT()) return
         if (!props.hasOwnProperty("ManufacturerData")) return
         try{
             const md = this.getManufacturerData(this.constructor.ManufacturerID)
-            if (md && md.length && md[0]==0x10){
+            if (md && md.length >= 8 && md[0]==0x10){
+                // Byte 7 is a plaintext copy of key[0]. Mismatch means wrong key or
+                // corrupted packet — discard before decrypting.
+                if (this.encryptionKey) {
+                    const key = Buffer.from(this.encryptionKey, 'hex')
+                    if (md[7] !== key[0]) return
+                }
                 const iv = md.readUInt16LE(5)
-                const now = Date.now()
+                // Drop exact duplicates (BlueZ can deliver the same advertisement twice)
                 if (this._lastIV !== undefined) {
-                    // Reset IV tracking if device was absent long enough to have restarted
-                    const stale = !this._lastAdTime || (now - this._lastAdTime) > 30000
-                    if (!stale) {
-                        // Forward distance modulo 2^16; handles wraparound (65535→0 = delta 1)
-                        const delta = (iv - this._lastIV + 0x10000) & 0xFFFF
-                        // delta==0: duplicate; delta>0x8000: IV went backwards → garbage packet
-                        if (delta === 0 || delta > 0x8000) return
-                    }
+                    const delta = (iv - this._lastIV + 0x10000) & 0xFFFF
+                    if (delta === 0) return
                 }
                 this._lastIV = iv
-                this._lastAdTime = now
                 const decData=this.decrypt(md)
+                if (!this.isDecryptedValid(decData)) return
                 this.emitValuesFrom(decData)
             }
         }

--- a/sensor_classes/Victron/VictronSensor.js
+++ b/sensor_classes/Victron/VictronSensor.js
@@ -178,6 +178,20 @@ const VictronIdentifier = require('./VictronIdentifier.js');
         try{
             const md = this.getManufacturerData(this.constructor.ManufacturerID)
             if (md && md.length && md[0]==0x10){
+                const iv = md.readUInt16LE(5)
+                const now = Date.now()
+                if (this._lastIV !== undefined) {
+                    // Reset IV tracking if device was absent long enough to have restarted
+                    const stale = !this._lastAdTime || (now - this._lastAdTime) > 30000
+                    if (!stale) {
+                        // Forward distance modulo 2^16; handles wraparound (65535→0 = delta 1)
+                        const delta = (iv - this._lastIV + 0x10000) & 0xFFFF
+                        // delta==0: duplicate; delta>0x8000: IV went backwards → garbage packet
+                        if (delta === 0 || delta > 0x8000) return
+                    }
+                }
+                this._lastIV = iv
+                this._lastAdTime = now
                 const decData=this.decrypt(md)
                 this.emitValuesFrom(decData)
             }

--- a/sensor_classes/Victron/VictronSensor.js
+++ b/sensor_classes/Victron/VictronSensor.js
@@ -171,7 +171,11 @@ const VictronIdentifier = require('./VictronIdentifier.js');
     // 0xFF means "unavailable / powering off" per the Victron spec and should be discarded.
     // VictronBatteryMonitor overrides this because its byte 0 is the TTG low byte, not state.
     isDecryptedValid(decData){
-        return decData.length > 0 && decData[0] !== 0xFF
+        if (decData.length > 0 && decData[0] === 0xFF) {
+            this.debug(`Discarding packet from ${this.getDisplayName()}: device state 0xFF (unavailable/powering off)`)
+            return false
+        }
+        return true
     }
 
     propertiesChanged(props){
@@ -185,7 +189,10 @@ const VictronIdentifier = require('./VictronIdentifier.js');
                 // corrupted packet — discard before decrypting.
                 if (this.encryptionKey) {
                     const key = Buffer.from(this.encryptionKey, 'hex')
-                    if (md[7] !== key[0]) return
+                    if (md[7] !== key[0]) {
+                        this.debug(`Key mismatch for ${this.getDisplayName()}: check encryption key`)
+                        return
+                    }
                 }
                 const iv = md.readUInt16LE(5)
                 // Drop exact duplicates (BlueZ can deliver the same advertisement twice)

--- a/sensor_classes/Victron/VictronSensor.js
+++ b/sensor_classes/Victron/VictronSensor.js
@@ -100,17 +100,18 @@ const VictronIdentifier = require('./VictronIdentifier.js');
         }
     }
 
-    _getOperationMode(buff, offset=0){
+    getOperationMode(buff, offset=0){
         const code = buff.readUInt8(offset)
         if (code === 0xFF) return null
         return {code: code, message: VC.OperationMode.get(code)}
     }
 
-    _getChargerError(buff, offset=1){
+    getChargerError(buff, offset=1){
         const code = buff.readUInt8(offset)
         if (code === 0xFF) return null
         return {code: code, message: VC.ChargerError.get(code)}
     }
+
    async init(){
         await super.init()
         this.addParameter(
@@ -191,9 +192,13 @@ const VictronIdentifier = require('./VictronIdentifier.js');
                     const key = Buffer.from(this.encryptionKey, 'hex')
                     if (md[7] !== key[0]) {
                         this.debug(`Key mismatch for ${this.getDisplayName()}: check encryption key`)
+                        this.emitKeyMismatchNotification()
                         return
                     }
                 }
+                // Clear key mismatch notification on successful packet
+                this.clearKeyMismatchNotification()
+
                 const iv = md.readUInt16LE(5)
                 // Drop exact duplicates (BlueZ can deliver the same advertisement twice)
                 if (this._lastIV !== undefined) {
@@ -233,6 +238,28 @@ const VictronIdentifier = require('./VictronIdentifier.js');
    prepareConfig(config){
         super.prepareConfig(config)
         config.params.modelID=this.getModelID()
+        this.encryptionKey=config.params.encryptionKey
+    }
+
+    emitKeyMismatchNotification(){
+        if (this._keyMismatchNotified) return
+        this._keyMismatchNotified = true
+        this.clearAllPaths()
+        const path = `notifications.sensors.${this.macAndName()}`
+        this.emitNotification(path, "alert", `Encryption key mismatch for ${this.getDisplayName()}: verify configuration`)
+    }
+
+    clearKeyMismatchNotification(){
+        if (!this._keyMismatchNotified) return
+        this._keyMismatchNotified = false
+        const path = `notifications.sensors.${this.macAndName()}`
+        this.emitNotification(path, null)
+    }
+
+    // Override super and only clear notification if key matches
+    clearNoContact(){
+        if (this._keyMismatchNotified) return
+        super.clearNoContact()
     }
 
 }

--- a/sensor_classes/Victron/VictronSensor.js
+++ b/sensor_classes/Victron/VictronSensor.js
@@ -102,18 +102,14 @@ const VictronIdentifier = require('./VictronIdentifier.js');
 
     _getOperationMode(buff, offset=0){
         const code = buff.readUInt8(offset)
-        return {
-            code: code,
-            message: VC.OperationMode.get(code)
-        }
+        if (code === 0xFF) return null
+        return {code: code, message: VC.OperationMode.get(code)}
     }
 
     _getChargerError(buff, offset=1){
         const code = buff.readUInt8(offset)
-        return {
-            code: code,
-            message: VC.ChargerError.get(code)
-        }
+        if (code === 0xFF) return null
+        return {code: code, message: VC.ChargerError.get(code)}
     }
    async init(){
         await super.init()

--- a/sensor_classes/VictronACCharger.js
+++ b/sensor_classes/VictronACCharger.js
@@ -29,11 +29,11 @@ class VictronACCharger extends VictronSensor{
         this.addDefaultParam("id")
 
         this.addMetadatum('state','', 'device state', 
-            (buff)=>{return this._getOperationMode(buff)})
+            (buff)=>{return this.getOperationMode(buff)})
         .default= "electrical.chargers.{id}.state"
 
         this.addMetadatum('chargerError','', 'charger error code', 
-            (buff)=>{return this._getChargerError(buff)}
+            (buff)=>{return this.getChargerError(buff)}
         )
             .default= "electrical.chargers.{id}.error"
 

--- a/sensor_classes/VictronBatteryMonitor.js
+++ b/sensor_classes/VictronBatteryMonitor.js
@@ -41,6 +41,10 @@ class VictronBatteryMonitor extends VictronSensor{
 
     characteristics=[]
 
+    // Byte 0 of BatteryMonitor decrypted data is the low byte of TTG, not device_state,
+    // so the base class 0xFF check would produce false positives. Skip it.
+    isDecryptedValid(decData){ return true }
+
     async initSchema(){
         await super.initSchema()
         this.addDefaultParam("batteryID").default="house"

--- a/sensor_classes/VictronDCDCConverter.js
+++ b/sensor_classes/VictronDCDCConverter.js
@@ -9,11 +9,11 @@ class VictronDCDCConverter extends VictronSensor{
         super.initSchema()
         this.addDefaultParam("id")
         this.addMetadatum('deviceState','', 'device state', 
-                (buff)=>{return this._getOperationMode(buff)})
+                (buff)=>{return this.getOperationMode(buff)})
         .default= "electrical.chargers.{id}.state"
 
         this.addMetadatum('chargerError','', 'charger error code', 
-                (buff)=>{return this._getChargerError(buff)})
+                (buff)=>{return this.getChargerError(buff)})
         .default= "electrical.chargers.{id}.error"
 
         this.addMetadatum('inputVoltage','V', 'input voltage', 

--- a/sensor_classes/VictronInverter.js
+++ b/sensor_classes/VictronInverter.js
@@ -10,7 +10,7 @@ class VictronInverter extends VictronSensor{
         super.initSchema()
         this.addDefaultParam("id")
         this.addMetadatum('state','', 'inverter device state', 
-            (buff)=>{return this._getOperationMode(buff)}
+            (buff)=>{return this.getOperationMode(buff)}
         )
         .default="electrical.inverters.{id}.state"
 

--- a/sensor_classes/VictronInverterRS.js
+++ b/sensor_classes/VictronInverterRS.js
@@ -12,12 +12,12 @@ class VictronInverterRS extends VictronSensor{
         super.initSchema()
         this.addDefaultParam("id")        
         this.addMetadatum('state','', 'device state', 
-            (buff)=>{return this._getOperationMode(buff)}
+            (buff)=>{return this.getOperationMode(buff)}
         )
         .default='electrical.inverters.{id}.state'    
         
         this.addMetadatum('chargerError','', 'charger error code', 
-            (buff)=>{return this._getChargerError(buff)}
+            (buff)=>{return this.getChargerError(buff)}
         )
         .default='electrical.inverters.{id}.error'
 

--- a/sensor_classes/VictronOrionXS.js
+++ b/sensor_classes/VictronOrionXS.js
@@ -10,11 +10,11 @@ class VictronOrionXS extends VictronSensor{
         super.initSchema()
         this.addDefaultParam("id")
         this.addMetadatum('deviceState','', 'device state', 
-            (buff)=>{return this._getOperationMode(buff)})
+            (buff)=>{return this.getOperationMode(buff)})
             .default="electrical.chargers.{id}.state"
     
         this.addMetadatum('chargerError','', 'charger error code', 
-            (buff)=>{return this._getChargerError(buff)})
+            (buff)=>{return this.getChargerError(buff)})
             .default="electrical.chargers.{id}.error"
 
         this.addMetadatum('outputVoltage','V', 'output voltage', 

--- a/sensor_classes/VictronSmartBatteryProtect.js
+++ b/sensor_classes/VictronSmartBatteryProtect.js
@@ -26,13 +26,13 @@ class VictronSmartBatteryProtect extends VictronSensor{
         this.addDefaultParam("id")
 
         this.addMetadatum('deviceState','', 'device state', 
-            (buff)=>{return this._getOperationMode(buff)})
+            (buff)=>{return this.getOperationMode(buff)})
 
         this.addMetadatum('outputStatus','', 'output status', //TODO
             (buff)=>{return (buff.readUInt8(2))})
 
         this.addMetadatum('chargerError','', 'charger error', 
-            (buff)=>{return this._getChargerError(buff,3)})
+            (buff)=>{return this.getChargerError(buff,3)})
         this.addMetadatum('alarmReason','', 'alarm reason', 
             (buff)=>{return buff.readUInt16LE(4)})
         this.addMetadatum('warningReason','', 'warning reason', //TODO

--- a/sensor_classes/VictronSolarCharger.js
+++ b/sensor_classes/VictronSolarCharger.js
@@ -19,7 +19,7 @@ class VictronSolarCharger extends VictronSensor{
         .default="electrical.solar.{id}.state"
     
         this.addMetadatum('chargerError','', 'charger error',
-            (buff)=>{return this._getChargerError(buff)})
+            (buff)=>{return this.getChargerError(buff)})
             .default="electrical.solar.{id}.error"
 
         this.addMetadatum('voltage','V', 'charger battery voltage', 

--- a/sensor_classes/VictronVEBus.js
+++ b/sensor_classes/VictronVEBus.js
@@ -9,7 +9,7 @@ class VictronVEBus extends VictronSensor{
     initSchema(){
         super.initSchema()
         this.addMetadatum('chargeState','', 'charge state', 
-            (buff)=>{ return this._getOperationMode(buff)})
+            (buff)=>{ return this.getOperationMode(buff)})
             
         this.addMetadatum('veBusError','', 'VE bus error',
             (buff)=>{return buff.readUInt8(1)}) //TODO


### PR DESCRIPTION
Summary

This PR hardens Victron advertising-mode decoding and improves sensor lifecycle behaviour around (re)connection and loss of contact. In practice it eliminates the spurious values and stale SignalK paths that show up when a Victron device powers off, when BLE advertisements are delivered duplicated or corrupted, and when the Bluetooth adapter isn't ready yet at plugin start.

Five logical changes:


Discard invalid/garbage Victron advertisements (device-state 0xFF, key mismatch, duplicate IV).
Return null for Operation Mode / Charger Error when the code is 0xFF.
Clear all registered paths when a device becomes unreachable or out of contact.
Re-emit RSSI on reconnect and fix sensor-list ordering so RSSI updates flow.
Retry Bluetooth adapter acquisition instead of failing immediately.
Revert previous path rewrite and only sanitize macAndName