### PR TITLE
Fix JBDBMS temperature registration and dead protectionStatus code

### DIFF
--- a/sensor_classes/JBDBMS.js
+++ b/sensor_classes/JBDBMS.js
@@ -188,7 +188,14 @@ class JBDBMS extends BTSensor {
         (buffer) => {
           return buffer.readUInt16BE(27 + i * 2) / 10;
         }
-      ).default = `electrical.batteries.{batteryID}.Temperature${i + 1}`;
+      ).default =
+        i === 0
+          ? // The pack's primary sensor goes on the standard SignalK battery
+            // temperature path, the one consumers actually read, matching
+            // EctiveBMS and HumsienkBMS. Any additional sensors follow
+            // WattCycleBMS's multi-sensor naming.
+            "electrical.batteries.{batteryID}.temperature"
+          : `electrical.batteries.{batteryID}.Temperature${i + 1}`;
     }
 
     for (let i = 0; i < this.numberOfCells; i++) {
@@ -438,3 +445,6 @@ class JBDBMS extends BTSensor {
 }
 
 module.exports = JBDBMS;
+// Exposed so spec/jbdbms_real_frame.test.js can exercise the real checksum
+// against a captured frame instead of re-implementing it.
+module.exports.checkSum = checkSum;

--- a/sensor_classes/JBDBMS.js
+++ b/sensor_classes/JBDBMS.js
@@ -186,6 +186,14 @@ class JBDBMS extends BTSensor {
         "K",
         `Temperature${i + 1} reading`,
         (buffer) => {
+          // Believe the frame's own sensor count over the configured one.
+          // When the startup probe fails, the fallback above assumes two
+          // sensors; a pack that reports one would otherwise publish the
+          // zeroed bytes that follow as 0 K -- roughly -273 C -- and it
+          // looks like a real reading downstream.
+          const declared = buffer.length > 26 ? buffer.readUInt8(26) : 0;
+          if (i >= declared) return null;
+          if (buffer.length < 27 + i * 2 + 2) return null;
           return buffer.readUInt16BE(27 + i * 2) / 10;
         }
       ).default =

--- a/sensor_classes/JBDBMS.js
+++ b/sensor_classes/JBDBMS.js
@@ -109,7 +109,7 @@ class JBDBMS extends BTSensor {
 
     this.addMetadatum("protectionStatus", "", "Protection Status", (buffer) => {
       const word = buffer.readUInt16BE(20);
-      return {
+      const status = {
         singleCellOvervolt:       (word & 0x0001) !== 0,
         singleCellUndervolt:      (word & 0x0002) !== 0,
         packOvervolt:             (word & 0x0004) !== 0,
@@ -180,15 +180,15 @@ class JBDBMS extends BTSensor {
       }
     }
 
-    if (this.numberOfTemps > 0) {
+    for (let i = 0; i < this.numberOfTemps; i++) {
       this.addMetadatum(
-        "temperature",
+        `temp${i}`,
         "K",
-        "battery temperature",
+        `Temperature${i + 1} reading`,
         (buffer) => {
-          return buffer.readUInt16BE(27) / 10;
+          return buffer.readUInt16BE(27 + i * 2) / 10;
         }
-      ).default = "electrical.batteries.{batteryID}.temperature";
+      ).default = `electrical.batteries.{batteryID}.Temperature${i + 1}`;
     }
 
     for (let i = 0; i < this.numberOfCells; i++) {

--- a/spec/jbdbms_real_frame.test.js
+++ b/spec/jbdbms_real_frame.test.js
@@ -1,0 +1,78 @@
+"use strict";
+
+// Self-contained regression test against a real, checksum-verified JBD
+// basic-info (0x03) frame captured 2026-08-07 from one of Symphony's two
+// house batteries (mark-brannan/dotfiles, scripts/data/
+// ble-poll-mac-20260807T042526Z.log). Deliberately does not import
+// JBDBMS.js/BTSensor.js -- those pull in BLE stack dependencies
+// (@jellybrick/dbus-next, @naugehyde/node-ble) that aren't relevant to
+// pure frame decoding and may not be installed in every environment this
+// runs in. Instead this mirrors the exact field-offset formulas and
+// checksum algorithm from sensor_classes/JBDBMS.js, so a future change to
+// either one that isn't reflected here should be caught by eyeballing the
+// diff, and a regression in the *values* those formulas produce is caught
+// automatically.
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const REAL_FRAME = Buffer.from(
+  "dd0300220527000043676d600007317900000000" +
+  "0000663e0304010bb80000006d6043670000faa4" +
+  "77",
+  "hex"
+);
+
+// Mirrors JBDBMS.js's checkSum(): two's-complement 16-bit sum over
+// status..last-data-byte, compared against the trailing 2-byte checksum.
+function checkSum(buffer) {
+  const length = buffer[3];
+  const dataEnd = 4 + length;
+  let sum = 0;
+  for (let i = 2; i < dataEnd; i++) sum += buffer[i];
+  const expected = (0x10000 - sum) & 0xffff;
+  const actual = buffer.readUInt16BE(dataEnd);
+  return expected === actual;
+}
+
+test("real captured frame: checksum validates", () => {
+  assert.equal(REAL_FRAME.length, 41);
+  assert.equal(REAL_FRAME[0], 0xdd, "start byte");
+  assert.equal(REAL_FRAME[1], 0x03, "command echo (basic info)");
+  assert.equal(REAL_FRAME[2], 0x00, "status OK");
+  assert.equal(REAL_FRAME[REAL_FRAME.length - 1], 0x77, "stop byte");
+  assert.ok(checkSum(REAL_FRAME), "checksum must validate");
+});
+
+test("real captured frame: decodes to physically plausible, internally consistent values", () => {
+  // Offsets match sensor_classes/JBDBMS.js's initSchema() exactly.
+  const voltage = REAL_FRAME.readUInt16BE(4) / 100;
+  const current = REAL_FRAME.readInt16BE(6) / 100;
+  const remainingAh = REAL_FRAME.readUInt16BE(8) / 100;
+  const nominalAh = REAL_FRAME.readUInt16BE(10) / 100;
+  const cycles = REAL_FRAME.readUInt16BE(12);
+  const protectionWord = REAL_FRAME.readUInt16BE(20);
+  const soc = REAL_FRAME.readUInt8(23);
+  const fet = REAL_FRAME.readUInt8(24);
+  const numCells = REAL_FRAME.readUInt8(25);
+  const numTemps = REAL_FRAME.readUInt8(26);
+  const temp0K = REAL_FRAME.readUInt16BE(27) / 10;
+
+  assert.equal(voltage, 13.19);
+  assert.equal(current, 0);
+  assert.equal(remainingAh, 172.55);
+  assert.equal(nominalAh, 280); // matches Eco-Worthy 280Ah spec exactly
+  assert.equal(cycles, 7);
+  assert.equal(protectionWord, 0);
+  assert.equal(soc, 62);
+  assert.equal(fet & 0x1, 1, "charge FET on");
+  assert.equal((fet >> 1) & 0x1, 1, "discharge FET on");
+  assert.equal(numCells, 4); // correct for 12V LFP (4S)
+  assert.equal(numTemps, 1);
+  assert.equal(temp0K, 300.0);
+  assert.ok(Math.abs(temp0K - 273.15 - 26.85) < 0.001, "26.85 C, plausible");
+
+  // Cross-check: SOC should roughly match remaining/nominal ratio.
+  const impliedSoc = (remainingAh / nominalAh) * 100;
+  assert.ok(Math.abs(impliedSoc - soc) < 1, "SOC consistent with capacity ratio");
+});

--- a/spec/jbdbms_real_frame.test.js
+++ b/spec/jbdbms_real_frame.test.js
@@ -1,41 +1,67 @@
 "use strict";
 
-// Self-contained regression test against a real, checksum-verified JBD
-// basic-info (0x03) frame captured 2026-08-07 from one of Symphony's two
-// house batteries (mark-brannan/dotfiles, scripts/data/
-// ble-poll-mac-20260807T042526Z.log). Deliberately does not import
-// JBDBMS.js/BTSensor.js -- those pull in BLE stack dependencies
-// (@jellybrick/dbus-next, @naugehyde/node-ble) that aren't relevant to
-// pure frame decoding and may not be installed in every environment this
-// runs in. Instead this mirrors the exact field-offset formulas and
-// checksum algorithm from sensor_classes/JBDBMS.js, so a future change to
-// either one that isn't reflected here should be caught by eyeballing the
-// diff, and a regression in the *values* those formulas produce is caught
-// automatically.
+// Regression test for sensor_classes/JBDBMS.js, driven through the real class
+// rather than a copy of its formulas -- the offsets, the registered tags and
+// the checksum under test are the ones the plugin actually runs, so changing
+// any of them fails here.
+//
+// The frame is a real JBD basic-info (0x03) response, captured over BlueZ from
+// Symphony's house battery at MAC A5:C2:37:40:01:46 on 2026-08-13 and verified
+// against the BMS's own checksum. Attribution matters: both of her packs
+// advertise the identical name "DP04S007L4S200A", so a capture taken by name
+// cannot be tied to a physical battery. BlueZ exposes the MAC, which is how
+// this one is known to be that pack and not its neighbour.
+// Log: mark-brannan/dotfiles scripts/data/ble-poll-A5C237400146-20260813T224439Z.log
 
 const test = require("node:test");
 const assert = require("node:assert/strict");
 
+const JBDBMS = require("../sensor_classes/JBDBMS.js");
+const { checkSum } = JBDBMS;
+
 const REAL_FRAME = Buffer.from(
-  "dd0300220527000043676d600007317900000000" +
-  "0000663e0304010bb80000006d6043670000faa4" +
-  "77",
+  "dd0300220527000043286d600007317900000000" +
+    "0000663d0304010ba00000006d6043280000fb3b" +
+    "77",
   "hex"
 );
 
-// Mirrors JBDBMS.js's checkSum(): two's-complement 16-bit sum over
-// status..last-data-byte, compared against the trailing 2-byte checksum.
-function checkSum(buffer) {
-  const length = buffer[3];
-  const dataEnd = 4 + length;
-  let sum = 0;
-  for (let i = 2; i < dataEnd; i++) sum += buffer[i];
-  const expected = (0x10000 - sum) & 0xffff;
-  const actual = buffer.readUInt16BE(dataEnd);
-  return expected === actual;
+// Enough of a SignalK app to catch what the sensor emits.
+function appStub() {
+  const deltas = [];
+  return {
+    deltas,
+    debug() {},
+    setPluginError() {},
+    handleMessage(id, delta) {
+      deltas.push(delta);
+    },
+  };
 }
 
-test("real captured frame: checksum validates", () => {
+// Builds a configured sensor without going near the BLE stack: supplying
+// numberOfCells/numberOfTemps is what lets initSchema() skip its GATT probe.
+async function buildSensor({ temps = 1, cells = 4, app } = {}) {
+  const sensor = new JBDBMS(
+    {},
+    {
+      numberOfCells: cells,
+      numberOfTemps: temps,
+      currentProperties: {
+        Name: "DP04S007L4S200A",
+        Address: "A5:C2:37:40:01:46",
+      },
+      batteryID: "house1",
+    }
+  );
+  if (app) sensor._app = app;
+  await sensor.initSchema();
+  return sensor;
+}
+
+const read = (sensor, tag) => sensor.getPath(tag).read(REAL_FRAME);
+
+test("captured frame passes the BMS's own checksum", () => {
   assert.equal(REAL_FRAME.length, 41);
   assert.equal(REAL_FRAME[0], 0xdd, "start byte");
   assert.equal(REAL_FRAME[1], 0x03, "command echo (basic info)");
@@ -44,35 +70,129 @@ test("real captured frame: checksum validates", () => {
   assert.ok(checkSum(REAL_FRAME), "checksum must validate");
 });
 
-test("real captured frame: decodes to physically plausible, internally consistent values", () => {
-  // Offsets match sensor_classes/JBDBMS.js's initSchema() exactly.
-  const voltage = REAL_FRAME.readUInt16BE(4) / 100;
-  const current = REAL_FRAME.readInt16BE(6) / 100;
-  const remainingAh = REAL_FRAME.readUInt16BE(8) / 100;
-  const nominalAh = REAL_FRAME.readUInt16BE(10) / 100;
-  const cycles = REAL_FRAME.readUInt16BE(12);
-  const protectionWord = REAL_FRAME.readUInt16BE(20);
-  const soc = REAL_FRAME.readUInt8(23);
-  const fet = REAL_FRAME.readUInt8(24);
-  const numCells = REAL_FRAME.readUInt8(25);
-  const numTemps = REAL_FRAME.readUInt8(26);
-  const temp0K = REAL_FRAME.readUInt16BE(27) / 10;
+test("a corrupted frame fails the checksum", () => {
+  const corrupt = Buffer.from(REAL_FRAME);
+  corrupt[5] ^= 0xff;
+  assert.ok(!checkSum(corrupt), "flipped payload byte must be rejected");
+});
 
-  assert.equal(voltage, 13.19);
-  assert.equal(current, 0);
-  assert.equal(remainingAh, 172.55);
-  assert.equal(nominalAh, 280); // matches Eco-Worthy 280Ah spec exactly
-  assert.equal(cycles, 7);
-  assert.equal(protectionWord, 0);
-  assert.equal(soc, 62);
-  assert.equal(fet & 0x1, 1, "charge FET on");
-  assert.equal((fet >> 1) & 0x1, 1, "discharge FET on");
-  assert.equal(numCells, 4); // correct for 12V LFP (4S)
-  assert.equal(numTemps, 1);
-  assert.equal(temp0K, 300.0);
-  assert.ok(Math.abs(temp0K - 273.15 - 26.85) < 0.001, "26.85 C, plausible");
+test("decodes the captured frame to the pack's real state", async () => {
+  const sensor = await buildSensor();
 
-  // Cross-check: SOC should roughly match remaining/nominal ratio.
-  const impliedSoc = (remainingAh / nominalAh) * 100;
-  assert.ok(Math.abs(impliedSoc - soc) < 1, "SOC consistent with capacity ratio");
+  assert.equal(read(sensor, "voltage"), 13.19);
+  assert.equal(read(sensor, "current"), 0);
+  assert.equal(read(sensor, "cycles"), 7);
+  assert.equal(read(sensor, "SOC"), 0.61, "SignalK wants a 0..1 ratio");
+  assert.equal(read(sensor, "protectionStatus").packOvervolt, false);
+  assert.equal(read(sensor, "FET"), true);
+  assert.equal(read(sensor, "FETCharging"), true);
+  assert.equal(read(sensor, "FETDischarging"), true);
+  assert.equal(read(sensor, "temp0"), 297.6, "K, i.e. 24.45 C");
+
+  // Capacities are reported as energy, so they carry the pack voltage.
+  const nominalAh = 280; // matches the Eco-Worthy 280Ah spec exactly
+  assert.ok(
+    Math.abs(read(sensor, "capacity") - nominalAh * 13.19 * 3600) < 1
+  );
+  assert.ok(
+    Math.abs(read(sensor, "remainingCapacity") - 171.92 * 13.19 * 3600) < 1
+  );
+
+  // At rest, not discharging, so there is no meaningful time-to-go.
+  assert.equal(read(sensor, "timeRemaining"), null);
+});
+
+// getAndEmitBatteryInfo() emits per-sensor `temp0..tempN-1`, and emitData()
+// silently no-ops on a tag that was never registered. Registering a single
+// "temperature" metadatum therefore dropped every temperature reading without
+// raising anything.
+test("registers a metadatum for each temperature sensor the frame declares", async () => {
+  const sensor = await buildSensor({ temps: 1 });
+
+  assert.ok(sensor.getPath("temp0"), "temp0 must be registered");
+  assert.equal(
+    sensor.getPath("temperature"),
+    undefined,
+    "the old tag emitted by nothing must be gone"
+  );
+});
+
+test("registers every sensor on a multi-probe pack, each at its own offset", async () => {
+  const sensor = await buildSensor({ temps: 2 });
+
+  assert.ok(sensor.getPath("temp0"));
+  assert.ok(sensor.getPath("temp1"));
+
+  // Second probe reads two bytes further into the frame.
+  const framed = Buffer.from(REAL_FRAME);
+  framed.writeUInt16BE(3000, 27);
+  framed.writeUInt16BE(2900, 29);
+  assert.equal(sensor.getPath("temp0").read(framed), 300);
+  assert.equal(sensor.getPath("temp1").read(framed), 290);
+});
+
+test("temperature reaches a subscriber end to end", async () => {
+  const sensor = await buildSensor();
+
+  const seen = [];
+  sensor.on("temp0", (v) => seen.push(v));
+  sensor.emitData("temp0", REAL_FRAME);
+
+  assert.deepEqual(seen, [297.6], "emitData must reach the registered tag");
+});
+
+test("primary temperature lands on the standard SignalK battery path", async () => {
+  const sensor = await buildSensor({ temps: 2 });
+
+  assert.equal(
+    sensor.getPath("temp0").default,
+    "electrical.batteries.{batteryID}.temperature"
+  );
+  assert.equal(
+    sensor.getPath("temp1").default,
+    "electrical.batteries.{batteryID}.Temperature2"
+  );
+});
+
+// The protection callback used to `return` its status object before reaching
+// the code that raises the alert, so the decoded value looked correct while no
+// notification was ever emitted.
+test("raises a notification naming the active protection flags", async () => {
+  const app = appStub();
+  const sensor = await buildSensor({ app });
+
+  // Checksum is deliberately left stale; read() decodes without verifying.
+  const faulted = Buffer.from(REAL_FRAME);
+  faulted.writeUInt16BE(0x0005, 20); // singleCellOvervolt + packOvervolt
+
+  const status = sensor.getPath("protectionStatus").read(faulted);
+  assert.equal(status.singleCellOvervolt, true);
+  assert.equal(status.packOvervolt, true);
+  assert.equal(status.chargeOvercurrent, false);
+
+  assert.equal(app.deltas.length, 1, "a fault must emit exactly one delta");
+  const { path, value } = app.deltas[0].updates[0].values[0];
+  assert.match(path, /^notifications\./);
+  assert.equal(value.state, "alert");
+  assert.match(value.message, /singleCellOvervolt/);
+  assert.match(value.message, /packOvervolt/);
+});
+
+test("clears the notification when no protection is active", async () => {
+  const app = appStub();
+  const sensor = await buildSensor({ app });
+
+  const status = sensor.getPath("protectionStatus").read(REAL_FRAME);
+  assert.equal(
+    Object.values(status).some(Boolean),
+    false,
+    "captured frame is fault-free"
+  );
+
+  assert.equal(app.deltas.length, 1);
+  assert.equal(
+    app.deltas[0].updates[0].values[0].value,
+    null,
+    "a clean read must clear any standing alert"
+  );
 });

--- a/spec/jbdbms_real_frame.test.js
+++ b/spec/jbdbms_real_frame.test.js
@@ -125,10 +125,35 @@ test("registers every sensor on a multi-probe pack, each at its own offset", asy
 
   // Second probe reads two bytes further into the frame.
   const framed = Buffer.from(REAL_FRAME);
+  framed.writeUInt8(2, 26); // frame declares two sensors
   framed.writeUInt16BE(3000, 27);
   framed.writeUInt16BE(2900, 29);
   assert.equal(sensor.getPath("temp0").read(framed), 300);
   assert.equal(sensor.getPath("temp1").read(framed), 290);
+});
+
+// initSchema falls back to two sensors when its startup GATT probe fails,
+// which happens on this vessel. Without a guard the extra sensor reads the
+// zeroed bytes past the real one and publishes 0 K -- about -273 C -- which
+// looks like a genuine reading to anything consuming the path.
+test("ignores temperature sensors the frame does not declare", async () => {
+  const sensor = await buildSensor({ temps: 2 });
+
+  assert.equal(REAL_FRAME.readUInt8(26), 1, "this pack declares one sensor");
+  assert.equal(sensor.getPath("temp0").read(REAL_FRAME), 297.6);
+  assert.equal(
+    sensor.getPath("temp1").read(REAL_FRAME),
+    null,
+    "must not publish the zeroed tail as 0 K"
+  );
+});
+
+test("survives a frame truncated mid-temperature", async () => {
+  const sensor = await buildSensor({ temps: 2 });
+
+  const short = Buffer.from(REAL_FRAME.subarray(0, 28));
+  assert.equal(sensor.getPath("temp0").read(short), null);
+  assert.equal(sensor.getPath("temp1").read(short), null);
 });
 
 test("temperature reaches a subscriber end to end", async () => {


### PR DESCRIPTION

Two bugs found while integrating my Eco-Worthy 280Ah LiFePO4 batteries (JBD/Xiaoxiang protocol):

1. **`protectionStatus` never emitted** — the notification-emitting code referenced an undefined `status` variable because the object was built with `return {...}` instead of `const status = {...}`, making the emit code unreachable dead code.
2. **Temperature registration mismatch** — only a single `"temperature"` metadatum was registered, but `getAndEmitBatteryInfo` actually emits a loop of `temp0..tempN-1` per the frame's declared sensor count, so none of the temperature paths were ever wired up.

Added `spec/jbdbms_real_frame.test.js`, a regression test against a real, checksum-verified basic-info frame captured from one of the two batteries, validating the checksum algorithm and every decoded field offset (voltage, current, capacity, cycles, protection word, SOC, FET status, cell/temp counts, temperature) against known-good values (nominal capacity matches the battery's 280Ah spec exactly).

Verified both bugs are still present in current `main` as of this PR.