### PR TITLE
fix: emit notifications with a `message` key, and don't prepare an absent one

### DIFF
--- a/BTSensor.js
+++ b/BTSensor.js
@@ -1324,10 +1324,9 @@ class BTSensor extends EventEmitter {
 
   emitNotification(path, state, message, method = ["visual", "sound"]){
     if (!this._app) return
-    const msg = this.preparePath(message)
     const value = state == null
         ? null
-        : { state, method, msg }
+        : { state, method, message: this.preparePath(message) }
     this._app.handleMessage('bt-sensors-plugin-sk', {
         updates: [{
             $source: this.getName(),


### PR DESCRIPTION
`master` is currently red: `spec/jbdbms_real_frame.test.js` has two failing tests (48/50). Both trace to `emitNotification()` in `BTSensor.js`, and both are fixed by the same two-line change.

## Two bugs

**1. Wrong key.** The value was built as `{ state, method, msg }`. The SignalK notification shape is `message`, so every alert raised through this method arrived with no message — consumers reading `value.message` get `undefined`. Every other notification in the repo already spells it `message` (`notifyUnableToCommunicate`, `VictronSensor`, `VictronSolarCharger`, `VictronInverterRS`), and nothing reads `msg`, so this looks like a typo rather than a local convention.

**2. `preparePath` ran on an absent message.** It was called before the `state == null` check. The clear path — `emitNotification(path, null)` in `JBDBMS`'s `protectionStatus` — passes no message, so `preparePath` reached `str.substring(lastIndex)` on `undefined` and threw:

```
TypeError: Cannot read properties of undefined (reading 'substring')
    at JBDBMS.preparePath (BTSensor.js:1387:25)
    at JBDBMS.emitNotification (BTSensor.js:1479:22)
```

Moving the call inside the non-null branch addresses both: the key is correct, and it only runs when there is something to prepare.

## Emitted shape after the fix

```json
{ "path": "notifications.electrical.batteries.1.protectionStatus",
  "value": { "state": "alert", "method": ["visual","sound"],
             "message": "singleCellOvervolt, packOvervolt" } }
{ "path": "notifications.electrical.batteries.1.protectionStatus", "value": null }
```

## Tested

`npm test` on a clean checkout of `main`: 48/50 before, **50/50 after**. The two tests this fixes were already on `main` — they are not added or modified here. No other test changed behaviour, and no test file is touched by this PR.